### PR TITLE
Maybe this will finally get rid of errors?

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,9 +16,9 @@ Go to a page, click edit, and make your changes, using [markdown](https://guides
 
 When you save it ("make a commit"), there are three fields to fill out. *All of these are optional*, with default values, and in most cases it's fine to leave the defaults.
 
-* **The commit title**: By default it is something like "Update /[filename/]". You can usually leave this as is (often this is ideal), or you can be more precise, but keep it short.
+* **The commit title**: By default it is something like "Update \[filename\]". You can usually leave this as is (often this is ideal), or you can be more precise, but keep it short.
 * **Extended description**: Explain your changes, if you wish. Useful if you need more than the 50 characters available in the title.
-* **The branch name:** By default this will be a new branch, with a name like /[username/]-patch-1.  If you want to change it to something more semantic (eg /[username/]-easy-github-contributing), that can be helpful to the reviewers, but it's not necessary.  
+* **The branch name:** By default this will be a new branch, with a name like \[username\]-patch-1.  If you want to change it to something more semantic (eg \[username\]-easy-github-contributing), that can be helpful to the reviewers, but it's not necessary.  
 
 After you commit, you will be asked if you want to create a new pull request with the branch you created.  You'll again be presented with a few fields, which you can generally leave as is.
 

--- a/docs/engineering/drupal-site-building.md
+++ b/docs/engineering/drupal-site-building.md
@@ -68,7 +68,9 @@ We need to scope out high risk tickets to inform basic site architecture decisio
 * Complex permissions
 * Search
 
-### <a name="drupal-contrib"></a>We use established Drupal contrib projects rather than writing custom code.
+<a name="drupal-contrib"> </a>
+
+### We use established Drupal contrib projects rather than writing custom code.
 
 It's generally cheaper to maintain and the barrier to maintainability is lower (less programmer skills). There are often established best practices around projects that allow us to standardize. We can take advantage of other developers insights and skills.
 
@@ -215,6 +217,7 @@ Drupal has a notoriously poor content workflow and editing experience OOTB. Ther
 
 ### <a name="data"></a>We import and export data: Feeds and Migrate
 
+@todo:  
 //needs content
 
 ### <a name="social-media"></a>We include social media functions
@@ -431,7 +434,8 @@ We do this so that our pages are smaller, faster and simpler to theme as well as
 
 We do this to prioritize functionality and keep things maintainable and performant.
 
-### <a name="featurization-strategies"></a>We consider featurization strategies before starting a project.
+<a name="featurization-strategies"> </a>
+### We consider featurization strategies before starting a project.
 
 #### Strategies
 

--- a/docs/engineering/drupal-site-building.md
+++ b/docs/engineering/drupal-site-building.md
@@ -28,7 +28,7 @@
 * [We use/create panels layouts, rather than adding page specific layout adjustments](#panels-layouts)
 * [We configure streamlined and semantic markup by default](#markup)
 * [We set a "module budget" for a project](#module-budget)
-* [We consider various featurization strategies prior to starting a project](#featurization-strategies)
+* [We consider various featurization strategies prior to starting a project](#featurization)
 * [We avoid namespace conflicts](#avoid-conflicts)
 * [We use drush to update node access](#drush)
 * [We don't like media_gallery module](#media_gallery)
@@ -68,11 +68,11 @@ We need to scope out high risk tickets to inform basic site architecture decisio
 * Complex permissions
 * Search
 
-<a name="drupal-contrib"> </a>
 
-### We use established Drupal contrib projects rather than writing custom code.
 
-It's generally cheaper to maintain and the barrier to maintainability is lower (less programmer skills). There are often established best practices around projects that allow us to standardize. We can take advantage of other developers insights and skills.
+### <a name="drupal-contrib"></a> We use Drupal contrib projects rather than custom code.
+
+We use established Drupal contrib projects rather than writing custom code. It's generally cheaper to maintain and the barrier to maintainability is lower (less programmer skills). There are often established best practices around projects that allow us to standardize. We can take advantage of other developers insights and skills.
 
 #### How do we do this?
 
@@ -434,8 +434,8 @@ We do this so that our pages are smaller, faster and simpler to theme as well as
 
 We do this to prioritize functionality and keep things maintainable and performant.
 
-<a name="featurization-strategies"> </a>
-### We consider featurization strategies before starting a project.
+
+### <a name="featurization"></a> We consider featurization strategies before starting a project.
 
 #### Strategies
 


### PR DESCRIPTION
There are 6 errors in travis-ci check. 
Four are because I improperly escaped brackets. I think that should now be fixed. 
The other two are long headers in drupal-site-building. Rather than shorten the actual text, I just moved the anchor link out. Hopefully that'll do the trick.