### PR TITLE
Setting up team-based reviews for certain directories

### DIFF
--- a/.remarkrc.error
+++ b/.remarkrc.error
@@ -34,7 +34,6 @@
       "remark-lint-no-tabs",
       "remark-lint-no-undefined-references",
       "remark-lint-no-unused-definitions",
-      "remark-lint-table-pipe-alignment",
       "remark-lint-table-pipes",
       ["remark-lint-blockquote-indentation", "2"],
       ["remark-lint-checkbox-character-style", "consistent"],

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,12 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in the repo.
+* @CivicActions/civicactions-team 
+
+# Order is important. The last matching pattern has the most precedence.
+# So if a pull request only touches javascript files, only these owners
+# will be requested to review.
+docs/05-engineering @CivicActions/ca-engineering 
+
+# You can also use email addresses if you prefer.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,6 +7,6 @@
 # Order is important. The last matching pattern has the most precedence.
 # So if a pull request only touches javascript files, only these owners
 # will be requested to review.
-docs/05-engineering @CivicActions/ca-engineering 
+docs/05-engineering @CivicActions/engineering 
 
 # You can also use email addresses if you prefer.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,12 +1,17 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
+# Order is important. The last matching pattern has the most precedence.
 
 # These owners will be the default owners for everything in the repo.
 * @CivicActions/civicactions-team 
 
-# Order is important. The last matching pattern has the most precedence.
-# So if a pull request only touches javascript files, only these owners
-# will be requested to review.
-docs/05-engineering @CivicActions/engineering 
-
-# You can also use email addresses if you prefer.
+# These will automatically assign PRs that touch files in these directories to their respective teams for review.
+docs/00-contributing @CivicActions/docs
+docs/01-welcome-to-civicactions/ @CivicActions/civicactions-team
+docs/02-about-us/ @CivicActions/docs
+docs/03-policies/ @CivicActions/management
+docs/05-engineering/ @CivicActions/engineering 
+docs/06-project-management/ @CivicActions/pm
+docs/07-sales-and-marketing/ @CivicActions/sales
+docs/08-hr-admin/ @CivicActions/management
+docs/09-security/ @CivicActions/security

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,15 +3,15 @@
 # Order is important. The last matching pattern has the most precedence.
 
 # These owners will be the default owners for everything in the repo.
-* @CivicActions/civicactions-team 
+* @CivicActions/civicactions-team
 
 # These will automatically assign PRs that touch files in these directories to their respective teams for review.
 docs/00-contributing @CivicActions/docs
 docs/01-welcome-to-civicactions/ @CivicActions/civicactions-team
-docs/02-about-us/ @CivicActions/docs
+docs/02-about-us/ @CivicActions/civicactions-team
 docs/03-policies/ @CivicActions/management
-docs/05-engineering/ @CivicActions/engineering 
+docs/05-engineering/ @CivicActions/engineering
 docs/06-project-management/ @CivicActions/pm
-docs/07-sales-and-marketing/ @CivicActions/sales
+docs/07-sales-and-marketing/ @CivicActions/civicactions-team
 docs/08-hr-admin/ @CivicActions/management
 docs/09-security/ @CivicActions/security

--- a/docs/00-contributing/docs-governance.md
+++ b/docs/00-contributing/docs-governance.md
@@ -27,6 +27,10 @@ Ideally, each of the above working groups have their own backlog of documentatio
 
 > @todo or will we use github issues, with issue tags for each team?
 
-Github team management is an ongoing responsibility of the Docs working group, but is generally [taken care of during onboarding]( https://trello.com/c/I5L6gPiQ/174-add-to-github).
-
 The [CODEOWNERS](https://github.com/civicactions/handbook/blob/master/CODEOWNERS) file in the top level of this repo maps the governance of `docs/` directories to their respective github teams and CivicActions practice areas, and automatically assigns pull requests to that team for review, when a PR is submitted that.
+
+## Github team management
+
+Github team management is an ongoing responsibility of the Docs working group, but is generally [taken care of during onboarding](https://trello.com/c/I5L6gPiQ/174-add-to-github).
+
+To add someone to a team, to go the [subteam page](https://github.com/orgs/CivicActions/teams/civicactions-team/teams) and click *Add a member*.

--- a/docs/00-contributing/docs-governance.md
+++ b/docs/00-contributing/docs-governance.md
@@ -1,12 +1,12 @@
 # Documentation Governance
 
-Every team member is empowered to make [pull requests](git-workflow.md) changes to any part of the documentation, and every team member is encourage to review any pull request they want.
+Every team member is empowered to make [pull requests](git-workflow.md) to change any part of the documentation, and every team member is encourage to review any pull request.
 
-Ideally, pull requests should be assigned to team members who are subject matter experts. For example, changes to the LICENSE.md file were assigned to a lawyer (who happens to be a copyleft and FLOSS expert).  If you're not sure who to assign the PR too, you might want to ask in the #docs channel.
+Ideally, pull requests should be assigned to team members who are subject matter experts. For example, changes to the LICENSE.md file were assigned to a lawyer (who happens to be a copyleft and FLOSS expert). If you're not sure who to assign the PR too, you might want to ask in the #docs channel.
 
 ## Governance driven by practice area and working groups.
 
-We encourage each team at CivicActions (aka Working Group, Practice Area, Guild, etc) to take direct ownership over each documentation area. To that end, changes to files in certain directories require at least one review and approval from a member of the respective team. For example, changes to the [05-engineering](../05-engineering/) directory requires at least one review and approval from a member of the [Engineering Team](https://github.com/orgs/CivicActions/teams/engineering/members).
+We encourage each team at CivicActions (aka Working Group, Practice Area, Guild, etc) to take ownership over their respective documentation. To that end, changes to files in certain directories require at least one review and approval from a member of the respective team, and members of those teams will be notified of that PR. For example, changes to the [05-engineering](../05-engineering/) directory requires at least one review and approval from a member of the [Engineering Team](https://github.com/orgs/CivicActions/teams/engineering/members).
 
 These teams are listed on github as [subteams](https://github.com/orgs/CivicActions/teams/civicactions-team/teams) of the main [CivicActions team](https://github.com/orgs/CivicActions/teams/civicactions-team). If you want to join one of those teams, you can go to the team page and "Request to join". A maintainer of that team will receive a notification and can approve you. You can see the maintainers from the team page, feel free to bug them for an approval.
 

--- a/docs/00-contributing/docs-governance.md
+++ b/docs/00-contributing/docs-governance.md
@@ -6,22 +6,22 @@ Ideally, pull requests should be assigned to team members who are subject matter
 
 ## Governance driven by practice area and working groups.
 
-We encourage each team at CivicActions (aka Working Group, Practice Area, Guild, etc) to take direct ownership over each documentation area. To that end, changes to files in certain directories require at least one review and approval from a member of the respective team. For example, changes to the [05-engineering](../05-engineering/README) directory requires at least one review and approval from a member of the [Engineering Team](https://github.com/orgs/CivicActions/teams/engineering/members).
+We encourage each team at CivicActions (aka Working Group, Practice Area, Guild, etc) to take direct ownership over each documentation area. To that end, changes to files in certain directories require at least one review and approval from a member of the respective team. For example, changes to the [05-engineering](../05-engineering/) directory requires at least one review and approval from a member of the [Engineering Team](https://github.com/orgs/CivicActions/teams/engineering/members).
 
 These teams are listed on github as [subteams](https://github.com/orgs/CivicActions/teams/civicactions-team/teams) of the main [CivicActions team](https://github.com/orgs/CivicActions/teams/civicactions-team). If you want to join one of those teams, you can go to the team page and "Request to join". A maintainer of that team will receive a notification and can approve you. You can see the maintainers from the team page, feel free to bug them for an approval.
 
 | **Directory in `docs/`** | **Subteam (Working group / Practice Area)**   |
 |---|---|
-| [`00-contributing`](README/) | [Docs](https://github.com/orgs/CivicActions/teams/docs/members) |
-| [`01-welcome-to-civicactions`](../01-welcome-to-civicactions/README/)  | [Anyone](https://github.com/orgs/CivicActions/teams/civicactions-team/members) |
-| [`02-about-us`](../02-about-us/README/) | [Anyone](https://github.com/orgs/CivicActions/teams/civicactions-team/members)  |
-| [`03-policies`](../03-policies/README/)  | [Management](https://github.com/orgs/CivicActions/teams/management/members) |
-| [`04-how-we-work`](../04-how-we-work/README/)   | [Anyone](https://github.com/orgs/CivicActions/teams/civicactions-team/members) |
-| [`05-engineering`](../05-engineering/README/) | [Engineering](https://github.com/orgs/CivicActions/teams/engineering/members)  |
-| [`06-project-management`](../06-project-management/README/)  |  [Project Managers](https://github.com/orgs/CivicActions/teams/pm/members) |
-| [`07-sales-and-marketing`](../07-sales-and-marketing/README/) | [Anyone](https://github.com/orgs/CivicActions/teams/civicactions-team/members)  |
-| [`08-hr-admin`](../08-hr-admin/README/) |  [Management](https://github.com/orgs/CivicActions/teams/management/members)  |
-| [`09-security`](../09-security/README/) | [Security](https://github.com/orgs/CivicActions/teams/security/members)  |
+| [`00-contributing`](../00-contributing/) | [Docs](https://github.com/orgs/CivicActions/teams/docs/members) |
+| [`01-welcome-to-civicactions`](../01-welcome-to-civicactions/)  | [Anyone](https://github.com/orgs/CivicActions/teams/civicactions-team/members) |
+| [`02-about-us`](../02-about-us/) | [Anyone](https://github.com/orgs/CivicActions/teams/civicactions-team/members)  |
+| [`03-policies`](../03-policies/) | [Management](https://github.com/orgs/CivicActions/teams/management/members) |
+| [`04-how-we-work`](../04-how-we-work/)   | [Anyone](https://github.com/orgs/CivicActions/teams/civicactions-team/members) |
+| [`05-engineering`](../05-engineering/) | [Engineering](https://github.com/orgs/CivicActions/teams/engineering/members)  |
+| [`06-project-management`](../06-project-management/)  |  [Project Managers](https://github.com/orgs/CivicActions/teams/pm/members) |
+| [`07-sales-and-marketing`](../07-sales-and-marketing/) | [Anyone](https://github.com/orgs/CivicActions/teams/civicactions-team/members)  |
+| [`08-hr-admin`](../08-hr-admin/) |  [Management](https://github.com/orgs/CivicActions/teams/management/members)  |
+| [`09-security`](../09-security/) | [Security](https://github.com/orgs/CivicActions/teams/security/members) |
 
 Ideally, each of the above working groups have their own backlog of documentation tasks, and make documentation a regular part of their workflow.
 

--- a/docs/00-contributing/docs-governance.md
+++ b/docs/00-contributing/docs-governance.md
@@ -1,6 +1,6 @@
 # Documentation Governance
 
-Every team member is empowered to make [pull requests](git-workflow.md) to change any part of the documentation, and every team member is encourage to review any pull request.
+Every team member with a github account is empowered to make [pull requests](git-workflow.md) to change any part of the documentation, and every team member is encourage to review any pull request.
 
 Ideally, pull requests should be assigned to team members who are subject matter experts. For example, changes to the LICENSE.md file were assigned to a lawyer (who happens to be a copyleft and FLOSS expert). If you're not sure who to assign the PR too, you might want to ask in the #docs channel.
 

--- a/docs/00-contributing/docs-governance.md
+++ b/docs/00-contributing/docs-governance.md
@@ -1,11 +1,32 @@
 # Documentation Governance
 
-Every team member is empowered to make pull requests with changes to any part of the documentation, and every team member is empowered to review and approve those pull requests.  
+Every team member is empowered to make [pull requests](git-workflow.md) changes to any part of the documentation, and every team member is encourage to review any pull request they want.
 
-However, we want to encourage ownership of sections of the documentation by those who know the topics best. In some cases that may be an individual, but in most cases, that ownership is related to a practice area or working group within the company.  
+Ideally, pull requests should be assigned to team members who are subject matter experts. For example, changes to the LICENSE.md file were assigned to a lawyer (who happens to be a copyleft and FLOSS expert).  If you're not sure who to assign the PR too, you might want to ask in the #docs channel.
 
-Ideally, pull requests should be assigned to team members involved in whatever practice area the documentation relates to. For example, changes to the LICENSE.md file were assigned to our lawyer (who happens to be a copyleft and FLOSS expert).  If you're not sure who to assign the PR too, you might want to ask in the #docs channel.
+## Governance driven by practice area and working groups.
 
-You can learn more about pull requests in [git-workflow.md](git-workflow.md).
+We encourage each team at CivicActions (aka Working Group, Practice Area, Guild, etc) to take direct ownership over each documentation area. To that end, changes to files in certain directories require at least one review and approval from a member of the respective team. For example, changes to the [05-engineering](../05-engineering/README) directory requires at least one review and approval from a member of the [Engineering Team](https://github.com/orgs/CivicActions/teams/engineering/members).
 
-This governance doc will likely be expanded as we formalize some of the practice areas within the company.
+These teams are listed on github as [subteams](https://github.com/orgs/CivicActions/teams/civicactions-team/teams) of the main [CivicActions team](https://github.com/orgs/CivicActions/teams/civicactions-team). If you want to join one of those teams, you can go to the team page and "Request to join". A maintainer of that team will receive a notification and can approve you. You can see the maintainers from the team page, feel free to bug them for an approval.
+
+| **Directory in `docs/`** | **Subteam (Working group / Practice Area)**   |
+|---|---|
+| [`00-contributing`](README/) | [Docs](https://github.com/orgs/CivicActions/teams/docs/members) |
+| [`01-welcome-to-civicactions`](../01-welcome-to-civicactions/README/)  | [Anyone](https://github.com/orgs/CivicActions/teams/civicactions-team/members) |
+| [`02-about-us`](../02-about-us/README/) | [Anyone](https://github.com/orgs/CivicActions/teams/civicactions-team/members)  |
+| [`03-policies`](../03-policies/README/)  | [Management](https://github.com/orgs/CivicActions/teams/management/members) |
+| [`04-how-we-work`](../04-how-we-work/README/)   | [Anyone](https://github.com/orgs/CivicActions/teams/civicactions-team/members) |
+| [`05-engineering`](../05-engineering/README/) | [Engineering](https://github.com/orgs/CivicActions/teams/engineering/members)  |
+| [`06-project-management`](../06-project-management/README/)  |  [Project Managers](https://github.com/orgs/CivicActions/teams/pm/members) |
+| [`07-sales-and-marketing`](../07-sales-and-marketing/README/) | [Anyone](https://github.com/orgs/CivicActions/teams/civicactions-team/members)  |
+| [`08-hr-admin`](../08-hr-admin/README/) |  [Management](https://github.com/orgs/CivicActions/teams/management/members)  |
+| [`09-security`](../09-security/README/) | [Security](https://github.com/orgs/CivicActions/teams/security/members)  |
+
+Ideally, each of the above working groups have their own backlog of documentation tasks, and make documentation a regular part of their workflow.
+
+> @todo or will we use github issues, with issue tags for each team?
+
+Github team management is an ongoing responsibility of the Docs working group, but is generally [taken care of during onboarding]( https://trello.com/c/I5L6gPiQ/174-add-to-github).
+
+The [CODEOWNERS](https://github.com/civicactions/handbook/blob/master/CODEOWNERS) file in the top level of this repo maps the governance of `docs/` directories to their respective github teams and CivicActions practice areas, and automatically assigns pull requests to that team for review, when a PR is submitted that.

--- a/docs/04-how-we-work/tools/github.md
+++ b/docs/04-how-we-work/tools/github.md
@@ -9,14 +9,11 @@ GitHub is a publicly available, free service which hosts the source code for ten
 Many CivicActions employees will already have a GitHub account. If you don't have one yet, now's a great time to create one! Follow these steps:
 
 1. Sign up with a free profile on <https://github.com/join>.
-
-a. As always, please use a unique, secure password.
-
-b. Use a personal email account, not your CivicActions one, so that your GitHub account will be portable.
-
-1. Ask a coworker to add you to the [CivicActions team](https://github.com/orgs/CivicActions/teams/civicactions-team).
-2. Find out the details of the repositories you'll be working with.
-3. Good work! Now set up two-factor authentication: <https://help.github.com/articles/securing-your-account-with-two-factor-authentication-2fa/>
+    * Use a personal email account, not your CivicActions one, so that your GitHub account will be portable.
+    * As always, please use a unique, secure password.
+2. Ask a coworker to add you to the [CivicActions team](https://github.com/orgs/CivicActions/teams/civicactions-team) and any relevant [subteams](https://github.com/orgs/CivicActions/teams/civicactions-team/teams).
+3. Find out the details of the repositories you'll be working with.
+4. Good work! Now [set up two-factor authentication](https://help.github.com/articles/securing-your-account-with-two-factor-authentication-2fa/).
 
 ## Setting up Git and a local repository
 

--- a/docs/04-how-we-work/tools/github.md
+++ b/docs/04-how-we-work/tools/github.md
@@ -22,3 +22,12 @@ Unless you are only ever going to be editing a few handbook pages the "easy" way
 If you'd prefer not to use command-line tools, you may want to use Git Desktop: <https://desktop.github.com/>.
 
 Many projects will have special requirements for local repositories, especially for engineers. Ask your coworkers for help!
+
+## Managing teams and access
+
+We use Github Teams functionality for two purposes:
+
+1. Managing access to the Handbook to all [CivicActions Team](https://github.com/orgs/CivicActions/teams/civicactions-team) members, and [managing control over subdirectories](../../00-contributing/docs-governance.md) in the Handbook by [subteams](https://github.com/orgs/CivicActions/teams/civicactions-team/teams).
+2. Managing groups of collaborators that share the same access to more than one repo.  
+
+You don't need to create a Github team unless that team has special access to more than one repo.


### PR DESCRIPTION
This is based off a suggestion by Owen last week, to use a new feature of github that allows automatic PR review requests, based on github teams.  It's explained in the docs-governance.md file.  This is a big change to our workflow, although it only affect certain directories for now.  