### PR TITLE
Remove scrum blog posts link agileoverview.md

### DIFF
--- a/docs/04-how-we-work/agileoverview.md
+++ b/docs/04-how-we-work/agileoverview.md
@@ -5,7 +5,5 @@ CivicActions uses agile practices.
 * Read the [Agile Manifesto](http://agilemanifesto.org/) statement
 * Watch this [Agile video](https://www.commoncraft.com/video/agile-methodology)
 * Join the Agile Gov Leadership group via its [website](http://www.agilegovleaders.org/) and [LinkedIn](https://www.linkedin.com/grp/home?gid=6642487)
-* Read blog posts on CivicActions:
-    * <http://www.civicactions.com/category/agile>
-    * <http://www.civicactions.com/category/scrum>
+* Read CivicActions blog posts tagged as [Agile reads] (http://www.civicactions.com/category/agile).
 * For a deeper dive, visit our [agile-baseline documentation](agile-baseline/introduction.md).


### PR DESCRIPTION
removed link to 'scrum' blog posts as they have since been consolidated to just 'agile' posts on the website