### PR TITLE
Add a site_url to mkdocs.yml.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: CivicActions Handbook
 repo_url: https://github.com/CivicActions/handbook/
+site_url: https://civicactions-handbook.readthedocs.io/en/latest/
 theme:
     name: readthedocs
     highlightjs: true


### PR DESCRIPTION
This should fix a bug in Read The Docs where the "CivicActions Handbook" link in the header takes the user to the LICENSE page.