### PR TITLE
Renaming ca-timeoff to ca-schedule.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Conflict of Interest has been added to the Required Stuff Section
 
 October 5, 2015
 
-Updated the PTO policy so that the only email address that needs to be used to request time off is  ca-timeoff@lists.civicactions.net
+Updated the PTO policy so that the only email address that needs to be used to request time off is  ca-schedule@civicactions.net
 
 September 30, 2015
 

--- a/docs/02-about-us/general-contacts-and-listservs.md
+++ b/docs/02-about-us/general-contacts-and-listservs.md
@@ -19,7 +19,7 @@ We have a fairly flat structure, so feel free to contact anyone who you think ca
 ## Main Listservs
 
 *   Team-wide communication: ca-team@civicactions.net
-*   Request Timeoff: ca-timeoff@civicactions.net
+*   Request Timeoff: ca-schedule@civicactions.net
 *   HR Notices: ca-employees@civicactions.net
 *   Engineering: ca-dev@civicactions.net
 *   Project Management: ca-pm@civicactions.net

--- a/docs/03-policies/benefits-and-holidays.md
+++ b/docs/03-policies/benefits-and-holidays.md
@@ -27,12 +27,12 @@ Time off applies to exempt employees. We do not accrue sick days, vacation days 
 You do not need to justify time off, but (except for unexpected events or emergencies), it does need to be arranged in advance so the work will be covered. There is a procedure for this:
 
 1.  If you are working on an active project, discuss the impact of your absence with your project manager (this is especially important if there is flexibility in your dates) to get coverage and understand project impact.
-2.  Email <mailto:ca-timeoff@lists.civicactions.net> requesting the time and explain your plan for coverage as discussed with your PM & team.
+2.  Email <mailto:ca-schedule@civicactions.net> requesting the time and explain your plan for coverage as discussed with your PM & team.
 3.  When the time off is approved, your manager will simply "reply-all" to your original email and add it to Harvest's Forecast tool.
 4.  Then the admin will put it on the Master Out of Office Calendar.
 5.  Lastly, follow the [procedure for logging time off](../04-how-we-work/tools/harvest.md).
 
-If you are unexpectedly unable to work for any reason (e.g., illness, emergency, power outage), email <mailto:ca-timeoff@lists.civicactions.net>. It is not sufficient to notify only a member of your team or post something in Slack. If you do not have internet access, you can call our main number, 510-408-7510 but this is not an efficient way to get the word out. You should consider having your manager's phone number handy. Lastly, follow the procedure for [logging sick time off](../04-how-we-work/tools/harvest.md) in Harvest with CivicActions.
+If you are unexpectedly unable to work for any reason (e.g., illness, emergency, power outage), email <mailto:ca-schedule@civicactions.net>. It is not sufficient to notify only a member of your team or post something in Slack. If you do not have internet access, you can call our main number, 510-408-7510 but this is not an efficient way to get the word out. You should consider having your manager's phone number handy. Lastly, follow the procedure for [logging sick time off](../04-how-we-work/tools/harvest.md) in Harvest with CivicActions.
 
 Time off will be recorded simply to easily see any patterns that might otherwise be overlooked, including non-use. Unless it will cause an extreme hardship on the company and your team, no request for Time off under two weeks will be turned down.
 


### PR DESCRIPTION
To better reflect the fact that the ca-timeoff list should be used for scheduling not just time-off but also company travel and disrupted work schedules etc, it has been renamed ca-schedule@civicactions.net (the old addresses still work, of course).