### PR TITLE
Add IT Support / Halp section to slack.md

### DIFF
--- a/docs/04-how-we-work/tools/slack.md
+++ b/docs/04-how-we-work/tools/slack.md
@@ -23,6 +23,7 @@
 - To alert only those in a channel/group who are online, write **@here**.
 
 ## IT Support / Halp
+
 - Halp is a Slack bot that we use to submit requests to our internal support team, responsible for supporting:
   - Internal systems and services (Slack, Zoom, Google Groups, GitLab, CI server, etc.)
   - Project sandbox / CI escalations

--- a/docs/04-how-we-work/tools/slack.md
+++ b/docs/04-how-we-work/tools/slack.md
@@ -22,6 +22,17 @@
 - If you want to call attention to everyone subscribed to channel, write **@channel** or **@group**.
 - To alert only those in a channel/group who are online, write **@here**.
 
+## IT Support / Halp
+- Halp is a Slack bot that we use to submit requests to our internal support team, responsible for supporting:
+  - Internal systems and services (Slack, Zoom, Google Groups, GitLab, CI server, etc.)
+  - Project sandbox / CI escalations
+- To request support, do one of the following:
+  - Ping the internal support team directly using the @it-help handle in the relevant Slack channel
+  - Use the `/halp` slash command in the relevant Slack channel to create a support ticket yourself
+  - To quickly create a ticket directly from a Slack message, click "More actions" and select "Create Halp Ticket". Alternatively, react to the message using the `:ticket:` :ticket: emoji.
+  - DM any of the support team directly (@zoe, @daven, and @grugnog)
+- Halp will create a Slack thread representing the ticket to track its status and document further discussion
+
 ## Tips
 
 - Consider using the word "ping" to check on the availability of someone


### PR DESCRIPTION
Adapting [Halp / IT support announcement](https://docs.google.com/document/d/1Segqp6IO9nWJ_nsaqwGtZi5OPxpUEn1YyN9C6anuUt8/edit) into documentation language for inclusion in Slack section of Handbook under 04-how-we-work.