### PR TITLE
swapping the order of time off request workflow

### DIFF
--- a/docs/03-policies/benefits-and-holidays.md
+++ b/docs/03-policies/benefits-and-holidays.md
@@ -17,8 +17,25 @@ CivicActions is considered closed on the following holidays:
 | Thanksgiving                  | Fourth Thursday in November and the following Friday |
 | Christmas                     | December 25th\*                                      |
 
+If a holiday falls on a the weekend, the US office observes on the preceeding Friday for Saturday holidays and the following Monday for Sunday holidays.
+
 Employees are not encouraged to work on these holidays. If you feel it's necessary to work on a holiday, hourly, non-exempt employees will be compensated at their normal hourly rate, and will receive overtime where appropriate.
+
 Exempt employees who voluntarily work on holidays will not receive additional compensation. Absent unique circumstances related to the needs of the business, you do NOT need to log entries when the office is closed for a holiday. All non-exempt employees must obtain approval from their manager prior to performing work on a holiday, and must record all hours worked, regardless of whether such prior approval was obtained.
+
+## Notice, Scheduling, and Approval of Time Off
+
+You do not need to justify time off for traditional vacation or personal time, but it does need to be arranged in advance so the work will be covered. An exception to this rule is for unforeseeable events or emergencies.
+
+For time off related to any sick leave that is **foreseeable**, employees should provide advance notice as soon as possible, preferably at least seven days in advance. If the need for sick leave is **unforeseeable**, employees shall provide notice as soon as practicable.
+
+Employees should follow the following procedure for providing notice of, scheduling, and obtaining approval of paid time off:
+
+1. If you are working on an active project (internal or external), discuss the impact of your absence with your project manager & team to get coverage and clarify project impact. This is especially important if there is flexibility in your dates. This is not necessary if the need is related to sick time that is **unforeseeable**.
+1. Email <mailto:ca-schedule@civicactions.com> to request the time. Make sure to explain your plan for coverage as discussed with your PM & team. If you are providing notice where the need is related to sick time and is **unforeseeable**, there's no need to explain further.
+1. When the time off is approved, a manager will "reply-all" to your original email stating if the request is approved.
+1. Then your time off will be put on the Primary Out of Office Calendar and added to Harvest's Forecast tool for people planning purposes.
+1. Lastly, [follow the procedure](https://github.com/CivicActions/handbook/blob/master/docs/04-how-we-work/tools/harvest.md) for logging time off.
 
 ## Exempt Employees -- Time Off
 
@@ -55,20 +72,6 @@ Eligible employees may use paid time off under this policy beginning on their 90
 - take time off for bone marrow or organ donation by the employee or an eligible family member; or
 - take time off in connection with an employee's child to attend a school-related conference, meeting, or other event requested or required by a school administrator, teacher, or other professional staff member responsible for the child's education, or to attend a meeting regarding care provided to the child in connection with the child's health conditions or disability.
 
-## Notice, Scheduling, and Approval of Time Off
-
-You do not need to justify time off for traditional vacation or personal time, but it does need to be arranged in advance so the work will be covered. An exception to this rule is for unforeseeable events or emergencies.
-
-For time off related to any sick leave that is **foreseeable**, employees should provide advance notice as soon as possible, preferably at least seven days in advance. If the need for sick leave is **unforeseeable**, employees shall provide notice as soon as practicable.
-
-Employees should follow the following procedure for providing notice of, scheduling, and obtaining approval of paid time off:
-
-1. If you are working on an active project, discuss the impact of your absence with your project manager (this is especially important if there is flexibility in your dates) to get coverage and understand project impact, except where the need is related to sick leave that is **unforeseeable**.
-1. Email <mailto:ca-schedule@civicactions.net> requesting the time and explaining your plan for coverage as discussed with your PM & team, or simply providing notice where the need is related to sick leave and is **unforeseeable**.
-1. When the time off is approved, your manager will simply "reply-all" to your original email and add it to Harvest's Forecast tool.
-1. Then the administrator will put it on the Master Out of Office Calendar.
-1. Lastly, [follow the procedure](https://github.com/CivicActions/handbook/blob/master/docs/04-how-we-work/tools/harvest.md) for logging time off.
-
 ## Written Documentation of Time Off
 
 If an employee uses PTO for sick leave, including sick leave under applicable state or local law, for more than three consecutive scheduled work days, CivicActions may require reasonable documentation of the purpose for such leave. If the reason for time off is due to an employee's or a family member's own medical condition, verification from a health care provider is appropriate, but should not explain the nature of the condition and should not result in an unreasonable burden or expense on the employee. If the reason for time off is due to an employee's need for leave related to domestic violence, verification may include a police report, court order or other evidence from the court or a prosecuting attorney, other documentation from a victim advocate, attorney, member of the clergy, a medical or other professional, or an employee's own written statement.
@@ -80,9 +83,12 @@ CivicActions also reserves the right to require documentation verifying an emplo
 Time off pursuant to this policy is not intended for long-term leave or as a long-term care solution. As such, exempt employees on leaves of absences for more than thirty days, including otherwise unpaid leaves of absences, will not be eligible for paid time off beyond the first thirty days. CivicActions will require non-exempt employees to exhaust accrued, unused PTO concurrently with extended leaves of absences, including under the Family and Medical Leave Act or comparable state laws, if applicable.
 
 Employees who are eligible for any other paid leave under CivicActions policies will not receive paid time off under this policy while on such paid leave (for example, parental leave) in addition to other paid leave. Likewise, time off and any other paid leaves shall run concurrently such that the duration of any leave shall not extend beyond the longer of the available leave. For instance, an employee may be eligible for twelve weeks of paid parental leave under CivicActions' policy, but will not be eligible for additional time off after such leave.
+
 Similarly, employees who are eligible for wage replacement benefits while on an approved leave (for example, an employee who is eligible for workers' compensation, short-term disability, or long-term disability) will not receive paid time off compensation except as provided below.
+
 If an employee remains absent for seven or more calendar days due to his or her own illness or injury, the employee must apply for short-term disability benefits through the state-provided plan or, if applicable, a company-provided plan, by contacting People Ops Team at <mailto:peopleops@civicactions.com> to initiate a disability claim. Absences covered by short-term disability, including pregnancy-related disabilities, are not eligible for paid time off under this policy. However, **CivicActions will bridge the otherwise unpaid short-term disability waiting period with paid time off.** If the company becomes aware that an absence may qualify for short-term disability benefits, management or the People Ops Team will direct the employee to contact TriNet to apply for short-term disability benefits.
 Likewise, if an employee is absent for more than three consecutive work days due to a serious health condition or any other reason covered by the federal Family and Medical Leave Act or similar state laws ("FMLA"), the employee should contact the People Ops Team at <mailto:peopleops@civicactions.com> to apply for state and/or federal family medical leave ("FMLA leave"). For exempt employees, absences covered by FMLA leave are not eligible for compensation under this policy. However, **CivicActions will bridge up to thirty days of otherwise unpaid FMLA leave with paid time off.** Otherwise, if the exempt employee is approved for FMLA leave, any future leave taken for the same FMLA-qualifying serious health condition is exempt from time off compensation. Any future leave for the same FMLA-qualifying serious health condition, whether continuous or intermittent, shall also be designated as FMLA leave and counted against the employee's FMLA allotment, not time off. If the company becomes aware that an absence may be protected under the FMLA for reasons other than the employee's own serious health condition, management or **the PeopleOps Team** will direct the employee to contact **TriNet** to apply for FMLA leave.
+
 For information or questions concerning this policy and the use of time off during otherwise unpaid leaves of absence, short-term disability, or FMLA leave, the employee should contact **the PeopleOps Team** for assistance.
 
 ## Abuse of Time Off


### PR DESCRIPTION
I updated the time off request workflow numbered list + move that section up higher. I added a note about how we observe holidays that land on the weekend... I assume this is still, true? I also tried to break up some of the large chunks of text into more readable paragraphs. changed ca-schedule@civicactions.net references to .coms

[//]: # (rtdbot-start)

URL of RTD document: https://civicactions-handbook.readthedocs.io/en/akaroleff-patch-4/ ![Documentation Status](https://readthedocs.org/projects/civicactions-handbook/badge/?version=akaroleff-patch-4)

[//]: # (rtdbot-end)
