### PR TITLE
This is a minor, just a simplification

### DIFF
--- a/docs/05-engineering/accessibility.md
+++ b/docs/05-engineering/accessibility.md
@@ -14,7 +14,7 @@ We implement 508 and WCAG compliant websites so that people with all types of di
 ## When we do this
 
 - We always produce work that is accessible to people of all abilities, regardless of client. However, we recognize that the level of accessibility compliance and prioritization can be influenced by budgetary and contractual implications.
-- We aim to do accessibility work continuously, as a component of each design and development task. Accessibility scans should be performed on a per-ticket basis and signed off on before work is considered complete.
+- We aim to do accessibility work continuously, as part of our agile process. Accessibility scans should be performed on a per-ticket basis and signed off on before work is considered complete.
 - Accessibility should NOT BE left until the end of a project.
 
 ## General Accessibility Guidelines


### PR DESCRIPTION
CA is an agile shop. Building in agile into accessibility is something that should be part of how things are done, rather than focusing on the components or projects.

[//]: # (rtdbot-start)

URL of RTD document: https://civicactions-handbook.readthedocs.io/en/mgifford-patch-6/ ![Documentation Status](https://readthedocs.org/projects/civicactions-handbook/badge/?version=mgifford-patch-6)

[//]: # (rtdbot-end)
