### PR TITLE
This is just a correction in fact

### DIFF
--- a/docs/05-engineering/accessibility.md
+++ b/docs/05-engineering/accessibility.md
@@ -32,7 +32,7 @@ We implement 508 and WCAG compliant websites so that people with all types of di
 
 - Don't use the word "link" in your links or the term "click here".
 - Don't capitalize links: Some screen readers read capitalized text letter by letter.
-- Avoid ASCII characters. Text alternatives are recommended for ASCII smiley faces. If a link involves dashes (17 - 18 years), it is better to replace the hyphen with "to". Screen-readers do not read ASCII characters.
+- Avoid ASCII characters. Text alternatives are recommended for ASCII smiley faces. If a link involves dashes (17 - 18 years), it is better to replace the hyphen with "to". Screen-readers do not read all ASCII characters.
 - Avoid using URLs as link text. Screen readers read URLs letter by letter. Use descriptive link text.
 - Keep link text concise.
 - Generally, restrict the number of text links on a page. An exception to this rule is pagination/alphabetized links and these should include further contextual information/link text.


### PR DESCRIPTION
ASCII includes all alpha/numeric characters. Some screen readers have trouble with dashes and others.  The message about avoiding special characters is good. Plus we're all using UTF8 anyways on the web.

[//]: # (rtdbot-start)

URL of RTD document: https://civicactions-handbook.readthedocs.io/en/mgifford-patch-10/ ![Documentation Status](https://readthedocs.org/projects/civicactions-handbook/badge/?version=mgifford-patch-10)

[//]: # (rtdbot-end)
