### PR TITLE
"strive to" - always is a bold claim

### DIFF
--- a/docs/05-engineering/accessibility.md
+++ b/docs/05-engineering/accessibility.md
@@ -13,7 +13,7 @@ We implement 508 and WCAG compliant websites so that people with all types of di
 
 ## When we do this
 
-- We always produce work that is accessible to people of all abilities, regardless of client. However, we recognize that the level of accessibility compliance and prioritization can be influenced by budgetary and contractual implications.
+- We strive to produce work that is accessible to people of all abilities, regardless of client. However, we recognize that the level of accessibility compliance and prioritization can be influenced by budgetary and contractual implications.
 - We aim to do accessibility work continuously, as part of our agile process. Accessibility scans should be performed on a per-ticket basis and signed off on before work is considered complete.
 - Accessibility should NOT BE left until the end of a project.
 


### PR DESCRIPTION
We can't claim to always be accessible.

In the future I'd like to modify the 2nd sentence to be "We also recognize that accessibility compliance is very much influenced by budges and contracts." but think I'll deal with that afterwards.

[//]: # (rtdbot-start)

URL of RTD document: https://civicactions-handbook.readthedocs.io/en/mgifford-patch-3/ ![Documentation Status](https://readthedocs.org/projects/civicactions-handbook/badge/?version=mgifford-patch-3)

[//]: # (rtdbot-end)
