### PR TITLE
Update zoom.md

### DIFF
--- a/docs/050-how-we-work/tools/zoom.md
+++ b/docs/050-how-we-work/tools/zoom.md
@@ -23,7 +23,7 @@ Paid accounts are available for those who need them regularly (once a week or so
 - Zoom is the default video meeting tool for CivicActions as it easily allows participants to dial themselves in to the meeting
 - Slack has a shortcut to creating a meeting: Just enter "/zoom" in the channel or direct message where you want the meeting link to appear
 - Mute by default when joining: Settings > Audio and check "Always mute microphone when joining meeting"
-- Video off by default when joining: Settings > Video and check "Turn off my video when joining meeting"
+- Video off by default when joining (best practice is to have video on by default): Settings > Video and check "Turn off my video when joining meeting"
 - Display participant names: Settings > Video and check "Always display participant's name on their video"
 - Enable shortcuts outside of Zoom can be handy for (un)muting when Zoom is not your top window: Settings > Accessibility and select "Enable shortcuts even when the Zoom app is not in focus"
 - Screen share Mac shortcut: Cmd + Shift + S

--- a/docs/050-how-we-work/tools/zoom.md
+++ b/docs/050-how-we-work/tools/zoom.md
@@ -23,7 +23,7 @@ Paid accounts are available for those who need them regularly (once a week or so
 - Zoom is the default video meeting tool for CivicActions as it easily allows participants to dial themselves in to the meeting
 - Slack has a shortcut to creating a meeting: Just enter "/zoom" in the channel or direct message where you want the meeting link to appear
 - Mute by default when joining: Settings > Audio and check "Always mute microphone when joining meeting"
-- Video off by default when joining (best practice is to have video on by default): Settings > Video and check "Turn off my video when joining meeting"
+- Optional video off by default when joining a new call (_but best practice is to turn video on during the meeting once joined_): Settings > Video and check "Turn off my video when joining meeting"
 - Display participant names: Settings > Video and check "Always display participant's name on their video"
 - Enable shortcuts outside of Zoom can be handy for (un)muting when Zoom is not your top window: Settings > Accessibility and select "Enable shortcuts even when the Zoom app is not in focus"
 - Screen share Mac shortcut: Cmd + Shift + S


### PR DESCRIPTION
My attempt at clarifying the 'Video off by default' tip.

[//]: # (rtdbot-start)

URL of RTD document: https://civicactions-handbook.readthedocs.io/en/dmundra-zoom-tips-clarification/ ![Documentation Status](https://readthedocs.org/projects/civicactions-handbook/badge/?version=dmundra-zoom-tips-clarification)

[//]: # (rtdbot-end)
