### PR TITLE
timeoff email list

### DIFF
--- a/docs/040-employee-handbook-us/benefits-and-holidays.md
+++ b/docs/040-employee-handbook-us/benefits-and-holidays.md
@@ -39,6 +39,7 @@ Employees should follow the following procedure for providing notice of, schedul
 1. Lastly, [follow the procedure](https://github.com/CivicActions/handbook/blob/master/docs/050-how-we-work/tools/harvest.md) for logging time off.
 
 **Sample emails to demonstrate how to communicate on the ca-schedule list:**
+
 - _Hello, I am out sick today. I've let my team know via slack not to expect me today._
 - _Hello, I want to take Aug 1-7 off. I will coordinate coverage with my team and remind them again prior to my time off._
 - _Hello, I am doing a prodev workshop on Feb 1. I'm cc'ing my team here to let them know I will be out that day._

--- a/docs/040-employee-handbook-us/benefits-and-holidays.md
+++ b/docs/040-employee-handbook-us/benefits-and-holidays.md
@@ -33,9 +33,16 @@ Employees should follow the following procedure for providing notice of, schedul
 
 1. If you are working on an active project (internal or external), discuss the impact of your absence with your project manager & team to get coverage and clarify project impact. This is especially important if there is flexibility in your dates. This is not necessary if the need is related to sick time that is **unforeseeable**.
 1. Email <mailto:ca-schedule@civicactions.com> to request the time. Make sure to explain your plan for coverage as discussed with your PM & team. If you are providing notice where the need is related to sick time and is **unforeseeable**, there's no need to explain further.
+1. You will want to cc team members who will be affected by your timeoff (eg your project manager or your supervisor), or you can choose to slack them separately.
 1. When the time off is approved, a manager will "reply-all" to your original email stating if the request is approved.
 1. Then your time off will be put on the Primary Out of Office Calendar and added to Harvest's Forecast tool for people planning purposes.
 1. Lastly, [follow the procedure](https://github.com/CivicActions/handbook/blob/master/docs/050-how-we-work/tools/harvest.md) for logging time off.
+
+**Sample emails to demonstrate how to communicate on the ca-schedule list:**
+- _Hello, I am out sick today. I've let my team know via slack not to expect me today._
+- _Hello, I want to take Aug 1-7 off. I will coordinate coverage with my team and remind them again prior to my time off._
+- _Hello, I am doing a prodev workshop on Feb 1. I'm cc'ing my team here to let them know I will be out that day._
+- _Hello, I need tomorrow off for a last minute doctor appointment. I am cc'ing those that need to know on this email not to expect me tomorrow._
 
 ## Exempt Employees -- Time Off
 


### PR DESCRIPTION
Update how to use the ca-schedule list for time off

[//]: # (rtdbot-start)

URL of RTD document: https://civicactions-handbook.readthedocs.io/en/elizabethraley-patch-1/ ![Documentation Status](https://readthedocs.org/projects/civicactions-handbook/badge/?version=elizabethraley-patch-1)

[//]: # (rtdbot-end)
