### PR TITLE
Moved robots.txt file to docs root

### DIFF
--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,7 @@
+User-agent: *
+
+Disallow: /
+
+Allow: /en/latest
+
+Sitemap: https://handbook.civicactions.com/sitemap.xml

--- a/robots.txt
+++ b/robots.txt
@@ -1,7 +1,0 @@
-User-agent: *
-
-Disallow: /
-
-Allow: /en/latest
-
-Sitemap: https://handbook.civicactions.com/sitemap.xml


### PR DESCRIPTION
Seems like #688 didn't exactly work. So moving it to the docs/ folder.

[//]: # (rtdbot-start)

URL of RTD document: https://civicactions-handbook.readthedocs.io/en/dmundra-mv-robots-txt/ ![Documentation Status](https://readthedocs.org/projects/civicactions-handbook/badge/?version=dmundra-mv-robots-txt)

[//]: # (rtdbot-end)
