### PR TITLE
Fen incident patch 1

### DIFF
--- a/docs/100-security/incident-response-plan.md
+++ b/docs/100-security/incident-response-plan.md
@@ -48,7 +48,7 @@ This document describes the process that the CivicActions Incident Response Team
 - roles and responsibilities during and after incidents
 - overview of the steps to follow for resolution
 
-_During an incident, the [IRP checklist](incident-response-checklist.md) may be more useful as it contains bulleted, actionable items for the IR Team to follow._
+_During an incident, the [IRP checklist](incident-response-checklist.md) may be more useful as it contains bulleted, actionable items for the IR Team to follow. For most non-project-related incidents, see the [Security Incidents](https://handbook.civicactions.com/en/latest/100-security/incidents/) page._
 
 ## Roles and Responsibilities
 

--- a/docs/100-security/incidents.md
+++ b/docs/100-security/incidents.md
@@ -29,7 +29,7 @@ See [Reporting an incident](#reporting-an-incident). Even if you don't think som
 
 ## Reporting an incident
 
-Report any potential incident as soon as possible. Time is critical so that the Security team can initiate our Incident Response.
+Report any potential incident as soon as possible. Time is critical so that the Security team can initiate our [Incident Response Plan](https://handbook.civicactions.com/en/latest/100-security/incident-response-plan/) (if needed).
 
 ### To report a security incident
 


### PR DESCRIPTION
The Security Incidents page <https://handbook.civicactions.com/en/latest/100-security/incidents/> should be the go-to page for internal incidents such as phishing. This PR cross0links this page with the more complete (and complaex) IR-Plan page.

[//]: # (rtdbot-start)

URL of RTD document: https://civicactions-handbook.readthedocs.io/en/fen-incident-patch-1/ ![Documentation Status](https://readthedocs.org/projects/civicactions-handbook/badge/?version=fen-incident-patch-1)

[//]: # (rtdbot-end)
