### PR TITLE
Paul seems to have taken down this extension

### DIFF
--- a/docs/050-how-we-work/tools/browserextensions.md
+++ b/docs/050-how-we-work/tools/browserextensions.md
@@ -8,7 +8,6 @@ You may also want to talk with your project team members to see what browser ext
 - [Zoom](https://chrome.google.com/webstore/detail/zoom-scheduler/kgjfgplpablkjnlkjmjdecgdpfankdle)
 - [Harvest for Trello](https://www.getharvest.com/trello-time-tracking)
 - [Scrum for Trello](http://scrumfortrello.com/)
-- [Boards for Trello](http://paulferrett.com/boards-for-trello/)
 - [Show Card Numbers for Trello](https://chrome.google.com/webstore/detail/show-card-numbers-for-tre/pjhjdehkaggmpebggjonlhleidlodepi?hl=en)
 - [Boomerang for Gmail](https://chrome.google.com/webstore/detail/boomerang-for-gmail/mdanidgdpmkimeiiojknlnekblgmpdll?hl=en)
 


### PR DESCRIPTION
Present link just goes to here https://www.paulferrett.com/

Nothing for it on GitHub

[//]: # (rtdbot-start)

URL of RTD document: https://civicactions-handbook.readthedocs.io/en/mgifford-patch-4/ ![Documentation Status](https://readthedocs.org/projects/civicactions-handbook/badge/?version=mgifford-patch-4)

[//]: # (rtdbot-end)
