### PR TITLE
Dropping Trello Time keeping & Boomerang

### DIFF
--- a/docs/050-how-we-work/tools/browserextensions.md
+++ b/docs/050-how-we-work/tools/browserextensions.md
@@ -6,10 +6,8 @@ You may also want to talk with your project team members to see what browser ext
 
 - [LastPass](https://lastpass.com/misc_download2.php)
 - [Zoom](https://chrome.google.com/webstore/detail/zoom-scheduler/kgjfgplpablkjnlkjmjdecgdpfankdle)
-- [Harvest for Trello](https://www.getharvest.com/trello-time-tracking)
 - [Scrum for Trello](http://scrumfortrello.com/)
 - [Show Card Numbers for Trello](https://chrome.google.com/webstore/detail/show-card-numbers-for-tre/pjhjdehkaggmpebggjonlhleidlodepi?hl=en)
-- [Boomerang for Gmail](https://chrome.google.com/webstore/detail/boomerang-for-gmail/mdanidgdpmkimeiiojknlnekblgmpdll?hl=en)
 
 ## Firefox browser extensions
 


### PR DESCRIPTION
Based on discussions with Owen on Slack, suggesting that we drop these two extensions.

[//]: # (rtdbot-start)

URL of RTD document: https://civicactions-handbook.readthedocs.io/en/mgifford-patch-4/ ![Documentation Status](https://readthedocs.org/projects/civicactions-handbook/badge/?version=mgifford-patch-4)

[//]: # (rtdbot-end)
