### PR TITLE
Should Harvest be changed to Unanet?

### DIFF
--- a/docs/030-policies/leaving-civicactions.md
+++ b/docs/030-policies/leaving-civicactions.md
@@ -58,4 +58,4 @@ CivicActions will also post a message in #announcements about the person departi
 ### Manager
 
 - Work with the employee to transition the employee's workload to other team members.
-- Ensure they complete their last timesheet in Harvest.
+- Ensure they complete their last timesheet in Unanet.


### PR DESCRIPTION
This page mentions logging time to Harvest, but the other on-boarding docs list Unanet as the company time tracking software. Should Harvest on this page be changed to Unanet?

[//]: # (rtdbot-start)

URL of RTD document: https://civicactions-handbook.readthedocs.io/en/dcgoodwin2112-patch-1/ ![Documentation Status](https://readthedocs.org/projects/civicactions-handbook/badge/?version=dcgoodwin2112-patch-1)

[//]: # (rtdbot-end)
