### PR TITLE
Adding a link to the Google Workspace dashboard

### DIFF
--- a/docs/050-how-we-work/tools/skills-base.md
+++ b/docs/050-how-we-work/tools/skills-base.md
@@ -17,7 +17,7 @@ Team members should report the data in good faith and to the best of their knowl
 
 ## Getting Started
 
-To log in to Skills Base use the Google Apps icon ![Google Apps icon](../../images/gsuite.png) in the header of any CivicActions Google page then scroll down and click on the Skills Base icon. You can also access this through https://workspace.google.com/dashboard.
+To log in to Skills Base use the Google Apps icon ![Google Apps icon](../../images/gsuite.png) in the header of any CivicActions Google page then scroll down and click on the Skills Base icon. You can also access this through the [Google Workspace dashboard](https://workspace.google.com/dashboard).
 
 When you first log in you will need to go through a short onboarding:
 


### PR DESCRIPTION
As a reader of the docs, i scanned the content for a link a few times but didn't see it. I think this improves scannability of the content (which may be undesireable, since careful reading _is_ required).

[//]: # (rtdbot-start)

URL of RTD document: https://civicactions-handbook.readthedocs.io/en/kevwalsh-skills-base-link/ ![Documentation Status](https://readthedocs.org/projects/civicactions-handbook/badge/?version=kevwalsh-skills-base-link)

[//]: # (rtdbot-end)
