### PR TITLE
Update civicactions-marketing.md

### DIFF
--- a/docs/080-sales-and-marketing/civicactions-marketing.md
+++ b/docs/080-sales-and-marketing/civicactions-marketing.md
@@ -19,9 +19,10 @@ We welcome everyone at CivicActions to be part of the conversation about how to 
 - `#civicactions-homesite`: Discussion, feedback, ideas, and project management for civicactions.com. You can also use this channel to request an update to any homesite content, such as your staff profile.
 
 ## Brand
+
 The CivicActions brand is professional yet friendly. You can get our logo, colors, and brand guidelines from the [CivicActions Style Guide](https://civicactions-style-guide.readthedocs.io/en/latest/README/). Please refer to this guide for all brand questions, or ask us in the `#brand` Slack channel.
 
-Here are some commonly requested branded templates that you can use:  
+Here are some commonly requested branded templates that you can use:
 
 - [Presentation templates](https://docs.google.com/presentation/u/0/?tgif=d&ftv=1) (Note: When you click a template from the Google Slides Template Gallery, it automatically creates a copy that you can edit. You don't have to worry about over-writing the template.)
 - Document templates (e.g., letterhead)
@@ -37,7 +38,7 @@ We attend events and conferences for a number of purposes, including:
 - Community participation / networking
 - Public speaking
 
-**Core events**  
+**Core events**
 The current list of "core events" that CivicActions sponsors and attends each year includes:
 
 - LibrePlanet (March)

--- a/docs/080-sales-and-marketing/civicactions-marketing.md
+++ b/docs/080-sales-and-marketing/civicactions-marketing.md
@@ -4,76 +4,60 @@ The marketing team uses a community-driven approach to strategically attract the
 
 - [Homesite at civicactions.com](https://civicactions.com/)
 - [Blog](https://medium.com/civicactions)
-- [Public speaking](https://civicactions.com/talks) at events and online
-- Participation in [communities](https://civicactions.com/communities) that support our work and [values](https://civicactions.com/values)
-- Contributions to industry organizations such as [Techwire](https://www.techwire.net/author/civicactions) and [Drupal](https://www.drupal.org/civicactions)
+- [Public speaking](https://medium.com/civicactions/tagged/civicactions-talks) at events and online
+- Contributions to industry organizations such as [ACT-IAC](https://www.actiac.org/), [Drupal](https://www.drupal.org/civicactions), [Technologists for the Public Good](https://www.publicgood.tech/), and others
 - Social media such as [Twitter](https://twitter.com/civicactions), [Facebook](https://www.facebook.com/CivicActions/), and [LinkedIn](https://www.linkedin.com/company/civicactions/)
 - Cultivating opportunities to appear in [press and news](https://civicactions.com/press)
-
-## Strategy and OKRs
-
-Marketing is using [Objectives and Key Results (OKRs)](https://www.whatmatters.com/faqs/do-i-need-okrs-goals/) to set and track measurable goals. View [Marketing OKRs here](https://drive.google.com/drive/folders/1bd0_pxo2fBOEOQpj1UU8cXPdLul5o_3-).
 
 ## Marketing-related Slack channels
 
 We welcome everyone at CivicActions to be part of the conversation about how to best reach our audiences with valuable content and ideas. Here are some Slack channels you can drop into for marketing related discussions:
 
-- `#marketing`: Discussion on marketing strategy, OKRs, initiatives, press, and general marketing inquirires or ideas
+- `#marketing`: Discussion on marketing strategy, content, initiatives, press, and general quesions or ideas
 - `#brand`: Brand-related assets, projects, resources, questions (logos, colors, styles, templates, letterhead...)
-- `#content`: Discuss and collaborate on any content-related initiatives like blog posts, articles, collateral, etc.
 - `#events`: General discussion, planning, and questions about events we may attend or sponsor. There are also channels specific to core events like #event-drupal-govcon, #event-cfa-summit, etc.
 - `#civicactions-homesite`: Discussion, feedback, ideas, and project management for civicactions.com. You can also use this channel to request an update to any homesite content, such as your staff profile.
 
-## Templates, logo, and branded collateral
+## Brand
+The CivicActions brand is professional yet friendly. You can get our logo, colors, and brand guidelines from the [CivicActions Style Guide](https://civicactions-style-guide.readthedocs.io/en/latest/README/). Please refer to this guide for all brand questions, or ask us in the `#brand` Slack channel.
 
-Here are some commonly requested items from Marketing:
+Here are some commonly requested branded templates that you can use:  
 
-- [Capabilities statements](https://drive.google.com/drive/folders/1wcO28ilLJYy3yxgt1Rsc0kB7AZ-qFSVs) (can be used as one-pagers at conferences and business meetings, or as a downloadable PDF)
-- [Brand assets](https://drive.google.com/drive/folders/14zUJJZdtlzmjt1lcQGUMrhLbpIi0cAya) (logo, colors, fonts, etc.)
-- ["About CivicActions" boilerplate](https://docs.google.com/document/d/1soAtSzxMk13AuCDZJTBo9h1M1jLIDp0tHolyd4yrsyI/edit#heading=h.na5wx72pqi6d) (for all the times you need a "blurb" about our company)
-- [Blog calendar and collaboration board](https://trello.com/b/9djaPUBZ/marketing-civicactions-blog) (where we co-work with team members on posts)
-- [Presentation slide deck template](https://docs.google.com/presentation/d/1uDn6UeISJJvAeC_gEOdDCLeaPrPwFlhziU2nKCl9zXs/edit#slide=id.g4e8e1b223a_0_50) (make a copy before using it!)
-
-Looking for something and can't find it here? Head over to #marketing in Slack and just ask us.
+- [Presentation templates](https://docs.google.com/presentation/u/0/?tgif=d&ftv=1) (Note: When you click a template from the Google Slides Template Gallery, it automatically creates a copy that you can edit. You don't have to worry about over-writing the template.)
+- Document templates (e.g., letterhead)
+- One-pager templates (COMING SOON)
 
 ## Events
 
 We attend events and conferences for a number of purposes, including:
 
-- Recruitment (Hiring Team)
-- Business Development (Sales Team)
-- Professional Development (Team Members)
-- Community Participation & Speaking
+- Recruitment
+- Business development
+- Professional development
+- Community participation / networking
+- Public speaking
 
-**Core Events**
+**Core events**  
 The current list of "core events" that CivicActions sponsors and attends each year includes:
 
 - LibrePlanet (March)
 - DrupalCon North America (April)
-- AGL Summit (May)
 - Code for America Summit (May)
 - DevOps Days DC (July)
 - Drupal GovCon (July)
 
-The Events Team manages the sponsorship and planning of the Core Events with support from team members as needed. **Event sponsorship and attendance are on hold until public health considerations are resolved.**
+**Event sponsorship and attendance are on hold until public health considerations are resolved.**
 
-### Speaking at Events
+### Speaking at events
 
 We highly encourage team members to share knowledge at conferences and have a number of initiatives to support these efforts.
 
-CivicActions will pay all costs for travel, registration, attendance, etc., for any team member that has conference presentation accepted at a Core Event. (Marketing > Core Events budget)
+CivicActions will pay all costs for travel, registration, attendance, etc., for any team member that has a conference presentation accepted at a Core Event (see Core Events list above).
 
-Here's a [running list of public presentations](https://airtable.com/shrwEraiWKvbAScC7) by CivicActions folks.
-To get started or share idea about attending or speaking at events, head over to the Slack channel #events.
+Here's a [running list of public presentations](https://airtable.com/shrK3eh7Nrx9vNtXt) by CivicActions folks.
+To get started or share an idea about attending or speaking at events, head over to the Slack channel #events.
 
 <!-- prettier-ignore -->
 CivicActions will pay all costs up to $1200/year per person to be used for travel, registration, attendance, etc. for any team member that has conference presentation accepted at a Non-Core Event. (Community Participation > Speaking Stipend)
 
 The Stipend is available three months after the beginning of employment and is reset at the calendar year. Speaking submissions and participation at non-core events are completely at the discretion of every team member, but we request you take into account your project delivery's schedule and check-in with your Project Manager to make sure it won't negatively impact your client delivery expectations.
-
-### Professional Development Stipend
-
-<!-- prettier-ignore -->
-Every team member has an annual $1,200 ProDev Stipend they can use to attend any conference or event to support their own professional learning. There is no requirement on the type of event a team member can attend, and it is not required or expected they would speak at a ProDev event.
-
-The ProDev stipend is not limited to events, and can also be used for books, webinars, online classes, apps, or any other ways of improving one's skills.

--- a/docs/080-sales-and-marketing/civicactions-marketing.md
+++ b/docs/080-sales-and-marketing/civicactions-marketing.md
@@ -61,4 +61,3 @@ To get started or share an idea about attending or speaking at events, head over
 If pre-approved by your manager and the marketing department, CivicActions may pay all costs up to $1200/year per person to be used for travel, registration, attendance, etc. for any team member that has conference presentation accepted at a Non-Core Event. (Community Participation > Speaking Stipend)
 
 The Stipend is available three months after the beginning of employment and is reset at the calendar year. Speaking submissions and participation at non-core events are completely at the discretion of every team member, but we request you take into account your project delivery's schedule and check-in with your Project Manager to make sure it won't negatively impact your client delivery expectations.
-


### PR DESCRIPTION
Updating old material. Removing sections that belong elsewhere (like section on ProDev stipend, which belong under the ProDev section of Handbook).