### PR TITLE
Fix for path problem in url

### DIFF
--- a/docs/050-how-we-work/bookmarks.md
+++ b/docs/050-how-we-work/bookmarks.md
@@ -46,7 +46,7 @@ Links to websites we use regularly.
 
 ### Browser Extensions
 
-- [See list browser extension page](https://handbook.civicactions.com/en/latest/050-how-we-work/tools/browserextensions/)
+- [See list browser extension page](../050-how-we-work/tools/browserextensions/)
 
 ### Accessibility
 


### PR DESCRIPTION


[//]: # (rtdbot-start)

URL of RTD document: https://civicactions-handbook.readthedocs.io/en/mgifford-patch-4-path/ ![Documentation Status](https://readthedocs.org/projects/civicactions-handbook/badge/?version=mgifford-patch-4-path)

[//]: # (rtdbot-end)
