### PR TITLE
Fix broken link on zoom.md

### DIFF
--- a/docs/050-how-we-work/tools/zoom.md
+++ b/docs/050-how-we-work/tools/zoom.md
@@ -5,7 +5,7 @@
 - We use [Zoom](https://zoom.us/) video conferencing by default. It is especially important for All Humans Calls (AHC). You will need to [download the free Zoom app](https://zoom.us/support/download). Zoom works on Windows, MacOS, [Linux](https://zoom.us/download?os=linux), iOS and Android computers. If necessary, Zoom also allows users to call in from a telephone (just don't forget to mute yourself!).
 - Login with your CivicActions email. You will see a link below the sign-in box that reads, "Or, sign in with Google..." so click that and proceed to login via your CivicActions email (may automatically do it if you're already logged in via your browser)
 - For easier scheduling of zoom video calls:
-  - download the [Zoom browser extensions](../browserextensions/#browser-extensions).
+  - download the [Zoom browser extensions](./browserextensions/#browser-extensions).
   - Once extension is installed, find the little Zoom logo on your toolbar and click sign-in.
   - Go into google calendar to start scheduling a meeting. Add attendees and set date/time as usual. Click on the blue "Make It a Zoom Meeting" button and notice that the zoom URL and dial-in info is now filled in for you.
 

--- a/docs/050-how-we-work/tools/zoom.md
+++ b/docs/050-how-we-work/tools/zoom.md
@@ -5,7 +5,7 @@
 - We use [Zoom](https://zoom.us/) video conferencing by default. It is especially important for All Humans Calls (AHC). You will need to [download the free Zoom app](https://zoom.us/support/download). Zoom works on Windows, MacOS, [Linux](https://zoom.us/download?os=linux), iOS and Android computers. If necessary, Zoom also allows users to call in from a telephone (just don't forget to mute yourself!).
 - Login with your CivicActions email. You will see a link below the sign-in box that reads, "Or, sign in with Google..." so click that and proceed to login via your CivicActions email (may automatically do it if you're already logged in via your browser)
 - For easier scheduling of zoom video calls:
-  - download the [Zoom browser extensions](./browserextensions/#browser-extensions).
+  - download the [Zoom browser extensions](../tools/browserextensions/#browser-extensions).
   - Once extension is installed, find the little Zoom logo on your toolbar and click sign-in.
   - Go into google calendar to start scheduling a meeting. Add attendees and set date/time as usual. Click on the blue "Make It a Zoom Meeting" button and notice that the zoom URL and dial-in info is now filled in for you.
 

--- a/docs/050-how-we-work/tools/zoom.md
+++ b/docs/050-how-we-work/tools/zoom.md
@@ -5,7 +5,7 @@
 - We use [Zoom](https://zoom.us/) video conferencing by default. It is especially important for All Humans Calls (AHC). You will need to [download the free Zoom app](https://zoom.us/support/download). Zoom works on Windows, MacOS, [Linux](https://zoom.us/download?os=linux), iOS and Android computers. If necessary, Zoom also allows users to call in from a telephone (just don't forget to mute yourself!).
 - Login with your CivicActions email. You will see a link below the sign-in box that reads, "Or, sign in with Google..." so click that and proceed to login via your CivicActions email (may automatically do it if you're already logged in via your browser)
 - For easier scheduling of zoom video calls:
-  - download the [Zoom browser extensions](../050-how-we-work/tools/browserextensions/#browser-extensions).
+  - download the [Zoom browser extensions](https://handbook.civicactions.com/en/latest/050-how-we-work/tools/browserextensions/#browser-extensions).
   - Once extension is installed, find the little Zoom logo on your toolbar and click sign-in.
   - Go into google calendar to start scheduling a meeting. Add attendees and set date/time as usual. Click on the blue "Make It a Zoom Meeting" button and notice that the zoom URL and dial-in info is now filled in for you.
 

--- a/docs/050-how-we-work/tools/zoom.md
+++ b/docs/050-how-we-work/tools/zoom.md
@@ -5,7 +5,7 @@
 - We use [Zoom](https://zoom.us/) video conferencing by default. It is especially important for All Humans Calls (AHC). You will need to [download the free Zoom app](https://zoom.us/support/download). Zoom works on Windows, MacOS, [Linux](https://zoom.us/download?os=linux), iOS and Android computers. If necessary, Zoom also allows users to call in from a telephone (just don't forget to mute yourself!).
 - Login with your CivicActions email. You will see a link below the sign-in box that reads, "Or, sign in with Google..." so click that and proceed to login via your CivicActions email (may automatically do it if you're already logged in via your browser)
 - For easier scheduling of zoom video calls:
-  - download the [Zoom browser extensions](https://handbook.civicactions.com/en/latest/050-how-we-work/tools/browserextensions/#browser-extensions).
+  - download the [Zoom browser extensions](../browserextensions/#browser-extensions).
   - Once extension is installed, find the little Zoom logo on your toolbar and click sign-in.
   - Go into google calendar to start scheduling a meeting. Add attendees and set date/time as usual. Click on the blue "Make It a Zoom Meeting" button and notice that the zoom URL and dial-in info is now filled in for you.
 

--- a/docs/050-how-we-work/tools/zoom.md
+++ b/docs/050-how-we-work/tools/zoom.md
@@ -5,7 +5,7 @@
 - We use [Zoom](https://zoom.us/) video conferencing by default. It is especially important for All Humans Calls (AHC). You will need to [download the free Zoom app](https://zoom.us/support/download). Zoom works on Windows, MacOS, [Linux](https://zoom.us/download?os=linux), iOS and Android computers. If necessary, Zoom also allows users to call in from a telephone (just don't forget to mute yourself!).
 - Login with your CivicActions email. You will see a link below the sign-in box that reads, "Or, sign in with Google..." so click that and proceed to login via your CivicActions email (may automatically do it if you're already logged in via your browser)
 - For easier scheduling of zoom video calls:
-  - download the [Zoom browser extensions](/050-how-we-work/tools/browserextensions/#browser-extensions).
+  - download the [Zoom browser extensions](../050-how-we-work/tools/browserextensions/#browser-extensions).
   - Once extension is installed, find the little Zoom logo on your toolbar and click sign-in.
   - Go into google calendar to start scheduling a meeting. Add attendees and set date/time as usual. Click on the blue "Make It a Zoom Meeting" button and notice that the zoom URL and dial-in info is now filled in for you.
 

--- a/docs/050-how-we-work/tools/zoom.md
+++ b/docs/050-how-we-work/tools/zoom.md
@@ -5,7 +5,7 @@
 - We use [Zoom](https://zoom.us/) video conferencing by default. It is especially important for All Humans Calls (AHC). You will need to [download the free Zoom app](https://zoom.us/support/download). Zoom works on Windows, MacOS, [Linux](https://zoom.us/download?os=linux), iOS and Android computers. If necessary, Zoom also allows users to call in from a telephone (just don't forget to mute yourself!).
 - Login with your CivicActions email. You will see a link below the sign-in box that reads, "Or, sign in with Google..." so click that and proceed to login via your CivicActions email (may automatically do it if you're already logged in via your browser)
 - For easier scheduling of zoom video calls:
-  - download the [Zoom browser extensions](/en/latest/050-how-we-work/tools/browserextensions/#browser-extensions).
+  - download the [Zoom browser extensions](/050-how-we-work/tools/browserextensions/#browser-extensions).
   - Once extension is installed, find the little Zoom logo on your toolbar and click sign-in.
   - Go into google calendar to start scheduling a meeting. Add attendees and set date/time as usual. Click on the blue "Make It a Zoom Meeting" button and notice that the zoom URL and dial-in info is now filled in for you.
 


### PR DESCRIPTION
Closes #830 
Fix broken link to browser extensions page. Leaving just relative `/en/latest/` in the link results in a link pointing to `/en/latest/en/latest` which ends up with a 404.

[//]: # (rtdbot-start)

URL of RTD document: https://civicactions-handbook.readthedocs.io/en/brdunfield-patch-1/ ![Documentation Status](https://readthedocs.org/projects/civicactions-handbook/badge/?version=brdunfield-patch-1)

[//]: # (rtdbot-end)
