### PR TITLE
Update and rename README.md to index.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This Handbook has been prepared to describe CivicActions' philosophy, working me
 
 ## This is not really the README you are looking for.
 
-The main handbook README is located at [docs/README.md](docs/README.md), which gets synced to readthedocs at <https://handbook.civicactions.com/en/latest/README/>
+The main handbook README is located at [docs/index.md](docs/index.md), which gets synced to readthedocs at <https://handbook.civicactions.com/en/latest/>
 
 ## CivicActions, Inc.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ civicactions.com
 
 ## License
 
-Copyright 2017-2021 CivicActions.
+Copyright 2017-2022 CivicActions.
 
 This work is licensed under the terms of the [Creative Commons Attribution 4.0 International (CC BY 4.0) license](docs/LICENSE.md).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # CivicActions Handbook
 
-[![Pipeline status](https://gitlab.com/civicactions/handbook/badges/master/pipeline.svg)](https://gitlab.com/civicactions/handbook/-/commits/master) [![Documentation Status](https://readthedocs.org/projects/civicactions-handbook/badge/?version=latest)](https://handbook.civicactions.com/en/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/civicactions-handbook/badge/?version=latest)](https://handbook.civicactions.com/en/latest/?badge=latest)
 
 ## CivicActions, Inc.
 
@@ -17,7 +17,7 @@ This Handbook has been prepared to describe the CivicActions philosophy, working
 
 ## License
 
-Copyright 2017 CivicActions.
+Copyright 2017-2022 CivicActions.
 
 This work is licensed under the terms of the [Creative Commons Attribution 4.0 International (CC BY 4.0) license](LICENSE.md).
 


### PR DESCRIPTION
Also removed gitlab pipeline status and updated year. Testing whether this closes #661 

[//]: # (rtdbot-start)

URL of RTD document: https://civicactions-handbook.readthedocs.io/en/index-page/ ![Documentation Status](https://readthedocs.org/projects/civicactions-handbook/badge/?version=index-page)

[//]: # (rtdbot-end)
