### PR TITLE
Test separate auto-commit from pre-commit (which is dropping this).

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,17 +9,19 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 0
-          persist-credentials: false
+          # Check out the right branch, and use a token so the new commit also runs actions.
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.PRE_COMMIT_TOKEN }}
       - uses: actions/setup-python@v2
       # Skip checks that don't auto-fix issues initially.
-      - uses: pre-commit/action@v2.0.0
+      - uses: pre-commit/action@v3.0.0
         env:
           SKIP: remark,codespell,mkdocs,check-yaml,check-json,check-added-large-files
+      - uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          token: ${{ secrets.PRE_COMMIT_TOKEN }}
+          commit_message: Apply pre-commit automatic fixes.
       # Final run without committing to ensure passes.
-      - uses: pre-commit/action@v2.0.0
+      - uses: pre-commit/action@v3.0.0
         env:
           # We skip checks that have their own actions.
           SKIP: remark,codespell

--- a/docs/020-about-us/culture.md
+++ b/docs/020-about-us/culture.md
@@ -116,7 +116,10 @@ The accessibility team has been busily working on our accessibility website, whi
 
 ## Common Questions
 
-### Q: What are some keys to success at CivicActions?
+
+
+
+#### Q: What are some keys to success at CivicActions?
 
 A: The most successful team members at CivicActions embody the culture. They have high emotional intelligence, are active listeners, are introspective and reflective, embrace failure, and do not tolerate a blame culture. It's also helpful if you have "self-starter" tendencies and enjoy taking initiative -- while also being a great team player.
 


### PR DESCRIPTION


[//]: # (rtdbot-start)

URL of RTD document: https://civicactions-handbook.readthedocs.io/en/auto-commit/ ![Documentation Status](https://readthedocs.org/projects/civicactions-handbook/badge/?version=auto-commit)

[//]: # (rtdbot-end)
