### PR TITLE
Forcing version mdx_truly_sane_lists to 1.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-mdx_truly_sane_lists
+mdx_truly_sane_lists==1.2


### PR DESCRIPTION
Tried this locally and the build is passing with Python 3 and version `1.3` of `mdx_truly_sane_lists` but I am guessing (confirmed!) since read the docs is using Python 2 that could be the issue so pinning the version `mdx_truly_sane_lists` to `1.2`.

Related ticket https://github.com/radude/mdx_truly_sane_lists/issues/14