### PR TITLE
Update team resume instructions

### DIFF
--- a/docs/010-welcome-to-civicactions/team-resume-instructions.md
+++ b/docs/010-welcome-to-civicactions/team-resume-instructions.md
@@ -6,6 +6,6 @@ We sometimes get requests for team resumes. We use a template for formatting tea
 
 1. Make a copy of the resume template from here: https://docs.google.com/document/d/1jVjUOql0sogCaIWGClpRpcUDir62SKT7HJ8r0rvtZkY/edit
 2. Follow the examples to fill out your information.
-3. When you are complete with your resume, export it as a PDF and refer to your onboarding instructions for the location to upload it.
+3. When you are complete with your resume, share your Google Doc with the PeopleOps Professional / onboarding specialist.
 4. Include the certs and degrees listed in your resume.
 5. A CivicActions team member will review your resume.


### PR DESCRIPTION
Since PeopleOps needs to be able to make changes to the resume, share the editable Google Doc instead of exporting to PDF.

[//]: # (rtdbot-start)

URL of RTD document: https://civicactions-handbook.readthedocs.io/en/jastraat-patch-1/ ![Documentation Status](https://readthedocs.org/projects/civicactions-handbook/badge/?version=jastraat-patch-1)

[//]: # (rtdbot-end)
