### PR TITLE
Fixing a typo

### DIFF
--- a/docs/050-how-we-work/practice-areas/accessibility-practice-area.md
+++ b/docs/050-how-we-work/practice-areas/accessibility-practice-area.md
@@ -8,7 +8,7 @@ In our [Accessibility Site](https://accessibility.civicactions.com/agile), we ar
 
 If you aren't part of the CivicActions team [let us know](https://accessibility.civicactions.com/contact) what you find helpful, if there are resources we should include or if there are ways we can improve. If you are part of CivicActions, please reach out on Slack.
 
-## We encourage C:
+## Join Us:
 
 - Join the #accessibility CivicActions Slack channel (CivicActions Internal)
 


### PR DESCRIPTION
Not sure how that slipped by us https://github.com/CivicActions/handbook/pull/880/files

[//]: # (rtdbot-start)

URL of RTD document: https://civicactions-handbook.readthedocs.io/en/mgifford-patch-2/ ![Documentation Status](https://readthedocs.org/projects/civicactions-handbook/badge/?version=mgifford-patch-2)

[//]: # (rtdbot-end)
