### PR TITLE
Adjusting CSS styling to fix a11y contrast errors

### DIFF
--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -43,3 +43,6 @@ h6 {
 .wy-side-nav-search > div.version {
   color: #fff7f6;
 }
+footer {
+  color: #545454;
+}

--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -27,7 +27,7 @@ h6 {
 .wy-nav-content a:visited {
   color: #db1b3b;
 }
-.wy-menu-vertical ul.subnav span {
+.wy-menu-vertical ul.subnav li.current span {
   color: #484849;
 }
 .wy-menu-vertical span {

--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -27,6 +27,9 @@ h6 {
 .wy-nav-content a:visited {
   color: #db1b3b;
 }
+.wy-menu-vertical ul.subnav span {
+  color: #484849;
+}
 .wy-menu-vertical span {
   color: #edf0f2;
   font-weight: bold;

--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -27,6 +27,10 @@ h6 {
 .wy-nav-content a:visited {
   color: #db1b3b;
 }
+.wy-menu-vertical span {
+  color: #b8b8b8;
+  font-weight: bold;
+}
 .wy-menu-vertical a:active {
   background-color: #db1b3b;
 }

--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -28,7 +28,7 @@ h6 {
   color: #db1b3b;
 }
 .wy-menu-vertical span {
-  color: #b8b8b8;
+  color: #edf0f2;
   font-weight: bold;
 }
 .wy-menu-vertical a:active {

--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -34,6 +34,9 @@ h6 {
 .wy-menu-vertical a:active {
   background-color: #db1b3b;
 }
+.wy-menu-vertical li.current a {
+  color: #484848;
+}
 .wy-side-nav-search {
   background-color: #db1b3b;
 }


### PR DESCRIPTION
CSS changes for the sidebar navigation and footer to fix color contrast issues reported by Wave.

For #914 

[//]: # (rtdbot-start)

URL of RTD document: https://civicactions-handbook.readthedocs.io/en/color-contrast-fixes/ ![Documentation Status](https://readthedocs.org/projects/civicactions-handbook/badge/?version=color-contrast-fixes)

[//]: # (rtdbot-end)
