### PR TITLE
Adjusting the color for menu hover and code blocks include code blocks with links

### DIFF
--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -53,10 +53,10 @@ code {
   color: #9d3429;
 }
 a code {
-  color: #1e5d86; 
+  color: #1e5d86;
 }
 a:hover code {
-  color: #1f5d86; 
+  color: #1f5d86;
 }
 footer {
   color: #545454;

--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -37,14 +37,26 @@ h6 {
 .wy-menu-vertical a:active {
   background-color: #db1b3b;
 }
+.wy-menu-vertical a:hover {
+  color: #e7e7e7;
+}
 .wy-menu-vertical li.current a {
-  color: #484848;
+  color: #404040;
 }
 .wy-side-nav-search {
   background-color: #db1b3b;
 }
 .wy-side-nav-search > div.version {
   color: #fff7f6;
+}
+code {
+  color: #9d3429;
+}
+a code {
+  color: #1e5d86; 
+}
+a:hover code {
+  color: #1f5d86; 
 }
 footer {
   color: #545454;


### PR DESCRIPTION
Noticed additional contrast bugs on https://handbook.civicactions.com/en/latest/000-contributing/docs-governance/ and on hovering over the sidebar menu items. For #914.

[//]: # (rtdbot-start)

URL of RTD document: https://civicactions-handbook.readthedocs.io/en/additional-css-changes/ ![Documentation Status](https://readthedocs.org/projects/civicactions-handbook/badge/?version=additional-css-changes)

[//]: # (rtdbot-end)
