### PR TITLE
Fixed link to engineering page and also adjusted default edit_uri

### DIFF
--- a/.config/mkdocs.yml
+++ b/.config/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: CivicActions Guidebook - Beta
 repo_url: https://github.com/CivicActions/handbook/
 site_url: https://handbook.civicactions.com/en/latest/
 docs_dir: "../.docs"
+edit_uri: edit/master/
 theme:
   name: material
   features:

--- a/about-this-guidebook/guidebook-governance.md
+++ b/about-this-guidebook/guidebook-governance.md
@@ -6,7 +6,7 @@ Ideally, pull requests should be assigned to team members who are subject matter
 
 ## Governance driven by practice area and working groups.
 
-We encourage each team at CivicActions (aka Working Group, Practice Area, Guild, etc.) to take ownership over their respective documentation. To that end, changes to files in certain directories require at least one review and approval from a member of the respective team, and members of those teams will be notified of that PR. For example, changes to the [engineering](../practice-areas/engineering) directory requires at least one review and approval from a member of the [Engineering Team](https://github.com/orgs/CivicActions/teams/engineering/members).
+We encourage each team at CivicActions (aka Working Group, Practice Area, Guild, etc.) to take ownership over their respective documentation. To that end, changes to files in certain directories require at least one review and approval from a member of the respective team, and members of those teams will be notified of that PR. For example, changes to the [engineering](../practice-areas/engineering/engineering-calls.md) directory requires at least one review and approval from a member of the [Engineering Team](https://github.com/orgs/CivicActions/teams/engineering/members).
 
 These teams are listed on GitHub as [subteams](https://github.com/orgs/CivicActions/teams/civicactions-team/teams) of the main [CivicActions team](https://github.com/orgs/CivicActions/teams/civicactions-team). If you want to join one of those teams, you can go to the team page and "Request to join". A maintainer of that team will receive a notification and can approve you. You can see the maintainers from the team page, feel free to bug them for an approval.
 


### PR DESCRIPTION
When clicking the pen icon on the page it goes to github with 'docs' in the URL hence the adjustment to fix that.