### PR TITLE
Remove reference to "000-contributing"

### DIFF
--- a/about-this-guidebook/README.md
+++ b/about-this-guidebook/README.md
@@ -18,4 +18,4 @@ Better than doing nothing at all:
 
 ## Writing documentation
 
-You should read the rest of this 000-contributing section if you intend to contribute beyond a Trello ticket, issue, or chatting in the #docs channel.
+You should read the rest of this section if you intend to contribute beyond a Trello ticket, issue, or chatting in the #docs channel.


### PR DESCRIPTION
The 000-contributing section name does not exist anymore. Proposing to remove it.

<!-- readthedocs-preview civicactions-handbook start -->
----
:books: Documentation preview :books:: https://civicactions-handbook--1002.org.readthedocs.build/en/1002/

<!-- readthedocs-preview civicactions-handbook end -->