### PR TITLE
Ignore statuscake links from linkchecker because it requires authentication

### DIFF
--- a/.config/markdown.links.config.json
+++ b/.config/markdown.links.config.json
@@ -14,6 +14,9 @@
       "pattern": "^https://app.skills-base.com/.*"
     },
     {
+      "pattern": "^https://app.statuscake.com/.*"
+    },
+    {
       "pattern": "^https://docs.google.com/.*"
     },
     {

--- a/common-practices-tools/security/contingency-plan.md
+++ b/common-practices-tools/security/contingency-plan.md
@@ -113,7 +113,7 @@ If GitLab becomes unavailable, systems will continue to operate in their current
 
 ### StatusCake
 
-- **Service:** <https://app.statuscake.com/>
+- **Service:** <https://status.statuscake.com/>
 - **Status:** <https://twitter.com/StatusCakeTeam>
 
 If there is a disruption in the StatusCake service, the Incident Response team will be notified by email.


### PR DESCRIPTION
Basing the change on report of errored links from https://github.com/CivicActions/guidebook/actions/runs/3872237135/jobs/6600854378

<!-- readthedocs-preview civicactions-handbook start -->
----
:books: Documentation preview :books:: https://civicactions-handbook--1005.org.readthedocs.build/en/1005/

<!-- readthedocs-preview civicactions-handbook end -->