### PR TITLE
Added theme override to adjust the text of the last update date.

### DIFF
--- a/.config/mkdocs.yml
+++ b/.config/mkdocs.yml
@@ -5,6 +5,8 @@ docs_dir: "../.docs"
 edit_uri: edit/master/
 theme:
   name: material
+  custom_dir: theme_overrides
+  language: custom
   features:
     - navigation.tabs
     - navigation.indexes

--- a/.config/theme_overrides/partials/languages/custom.html
+++ b/.config/theme_overrides/partials/languages/custom.html
@@ -1,0 +1,12 @@
+<!-- Import translations for language and fallback -->
+{% import "partials/languages/en.html" as language %}
+
+<!-- Define custom translations -->
+{% macro override(key) %}{{ {
+"source.file.date.updated": "This page was last updated on"
+}[key] }}{% endmacro %}
+
+<!-- Re-export translations -->
+{% macro t(key) %}{{
+override(key) or language.t(key) or fallback.t(key)
+}}{% endmacro %}

--- a/.config/theme_overrides/partials/languages/custom.html
+++ b/.config/theme_overrides/partials/languages/custom.html
@@ -2,11 +2,9 @@
 {% import "partials/languages/en.html" as language %}
 
 <!-- Define custom translations -->
-{% macro override(key) %}{{ {
-"source.file.date.updated": "This page was last updated on"
-}[key] }}{% endmacro %}
+{% macro override(key) %}{{ { "source.file.date.updated": "This page was last
+updated on" }[key] }}{% endmacro %}
 
 <!-- Re-export translations -->
-{% macro t(key) %}{{
-override(key) or language.t(key) or fallback.t(key)
-}}{% endmacro %}
+{% macro t(key) %}{{ override(key) or language.t(key) or fallback.t(key) }}{%
+endmacro %}

--- a/.config/theme_overrides/partials/source-file.html
+++ b/.config/theme_overrides/partials/source-file.html
@@ -1,0 +1,14 @@
+<hr>
+<div class="md-source-file">
+  <small>
+    {% if page.meta.git_revision_date_localized %}
+      {{ lang.t("source.file.date.updated") }} {{ page.meta.git_revision_date_localized }}.
+      {% if page.meta.git_creation_date_localized %}
+        <br>
+        {{ lang.t("source.file.date.created") }} {{ page.meta.git_creation_date_localized }}.
+      {% endif %}
+    {% elif page.meta.revision_date %}
+      {{ lang.t("source.file.date.updated") }} {{ page.meta.revision_date }}.
+    {% endif %}
+  </small>
+</div>

--- a/.config/theme_overrides/partials/source-file.html
+++ b/.config/theme_overrides/partials/source-file.html
@@ -1,14 +1,14 @@
-<hr>
+<hr />
 <div class="md-source-file">
   <small>
-    {% if page.meta.git_revision_date_localized %}
-      {{ lang.t("source.file.date.updated") }} {{ page.meta.git_revision_date_localized }}.
-      {% if page.meta.git_creation_date_localized %}
-        <br>
-        {{ lang.t("source.file.date.created") }} {{ page.meta.git_creation_date_localized }}.
-      {% endif %}
-    {% elif page.meta.revision_date %}
-      {{ lang.t("source.file.date.updated") }} {{ page.meta.revision_date }}.
-    {% endif %}
+    {% if page.meta.git_revision_date_localized %} {{
+    lang.t("source.file.date.updated") }} {{
+    page.meta.git_revision_date_localized }}. {% if
+    page.meta.git_creation_date_localized %}
+    <br />
+    {{ lang.t("source.file.date.created") }} {{
+    page.meta.git_creation_date_localized }}. {% endif %} {% elif
+    page.meta.revision_date %} {{ lang.t("source.file.date.updated") }} {{
+    page.meta.revision_date }}. {% endif %}
   </small>
 </div>


### PR DESCRIPTION
Following instructions from:
* https://squidfunk.github.io/mkdocs-material/setup/changing-the-language/?h=custom+translations#custom-translations
* https://squidfunk.github.io/mkdocs-material/customization/#setup-and-theme-structure

See preview to confirm text change.

<!-- readthedocs-preview civicactions-handbook start -->
----
:books: Documentation preview :books:: https://civicactions-handbook--1015.org.readthedocs.build/en/1015/

<!-- readthedocs-preview civicactions-handbook end -->