### PR TITLE
Replace trinet link

### DIFF
--- a/.config/markdown.links.config.json
+++ b/.config/markdown.links.config.json
@@ -39,6 +39,9 @@
       "pattern": "^https://support.zoom.us/.*"
     },
     {
+      "pattern": "^https://identity.trinet.com/.*"
+    },
+    {
       "NOTE: Intentional absolute self links below": "",
       "pattern": "^https://github.com/CivicActions/guidebook/tree/master/common-practices-tools/security/$"
     },

--- a/company-policies/new-hire-orientation/welcome.md
+++ b/company-policies/new-hire-orientation/welcome.md
@@ -30,5 +30,5 @@ CivicActions uses TriNet for outsourcing benefits, payroll, and human resources 
 
 #### Benefits
 
--   [Health, Dental and Vision Insurance - TriNet](https://login.trinet.com)
+-   [Health, Dental and Vision Insurance - TriNet](https://identity.trinet.com/)
 -   [401K - TPA](https://www.retirementaccountlogin.net/turningpoint/)


### PR DESCRIPTION
The previous trinet URL is showing up as 403 in our link checker. Trying https://identity.trinet.com/ to see if that errors out as well. It does, so need to ignore trinet for now.

<!-- readthedocs-preview civicactions-handbook start -->
----
:books: Documentation preview :books:: https://civicactions-handbook--1077.org.readthedocs.build/en/1077/

<!-- readthedocs-preview civicactions-handbook end -->