### PR TITLE
Update mkdocs.yml

### DIFF
--- a/.config/mkdocs.yml
+++ b/.config/mkdocs.yml
@@ -47,7 +47,7 @@ extra_javascript:
 # Navigation of the entire site is managed below, both the main menu items and their child pages.
 nav:
   - Home: README.md
-  - About CivicActions:
+  - About us:
       - Mission and values: about-civicactions/mission-values.md
       - Culture: about-civicactions/culture.md
       - Diversity, Equity, Inclusion, and Accessibility (DEIA):
@@ -86,7 +86,7 @@ nav:
       - Annual performance review: company-policies/annual-review-process.md
       - Performance management: company-policies/performance-management.md
       - Leaving Civicactions: company-policies/employment/leaving-civicactions.md
-      - Health, Safety and Security Policy: company-policies/health-safety-security.md
+      - Health, Safety, and Security Policy: company-policies/health-safety-security.md
       - New hire orientation:
           - Welcome to CivicActions!: company-policies/new-hire-orientation/welcome.md
           - Buddy program: company-policies/new-hire-orientation/buddy-program.md
@@ -98,7 +98,7 @@ nav:
           - Training resources: company-policies/new-hire-orientation/training-resources.md
           - Video call best practices: company-policies/new-hire-orientation/video-call-best-practices.md
           - Virtual workplace basics: company-policies/new-hire-orientation/virtual-workplace-basics.md
-  - Common practices and tools:
+  - Our practices and tools:
       - Agile:
           - Agile overview: common-practices-tools/agile/agile-overview.md
           - Agile practice: common-practices-tools/agile/agile-practices.md
@@ -131,7 +131,7 @@ nav:
           - Internal technical support: common-practices-tools/software-and-support/support.md
           - Bookmarks: company-policies/new-hire-orientation/bookmarks.md
           - Email: common-practices-tools/software-and-support/email.md
-          - Github: common-practices-tools/software-and-support/github.md
+          - GitHub: common-practices-tools/software-and-support/github.md
           - Google Calendar: common-practices-tools/software-and-support/google-calendar.md
           - Google Docs: common-practices-tools/software-and-support/google-docs.md
           - Google Meet: common-practices-tools/software-and-support/google-meet.md
@@ -159,10 +159,10 @@ nav:
           - Accessibility: practice-areas/engineering/accessibility.md
           - Drupal practice area: practice-areas/engineering/drupal-practice-area.md
           - Drupal - contributed vs. custom development: practice-areas/engineering/most-important-decision-in-developing-a-drupal-site-contributed-vs-custom-development.md
-          - Drupal developer tips for getting the most out of open source: practice-areas/engineering/drupal-developer-tips-for-getting-the-most-out-of-open-source.md
+          - Drupal developer tips to get the most out of open source: practice-areas/engineering/drupal-developer-tips-for-getting-the-most-out-of-open-source.md
           - Git: practice-areas/engineering/git.md
           - Security and compliance: practice-areas/engineering/security-compliance.md
-          - Tech Lead (TL) project role description: practice-areas/engineering/tech-lead.md
+          - Tech Lead project role description: practice-areas/engineering/tech-lead.md
       - Project management:
           - Checklists: practice-areas/project-management/project-management-checklists.md
           - Conflict resolution and growth mindset: practice-areas/project-management/growth-mindset.md
@@ -185,7 +185,7 @@ nav:
           - Team Working Agreements: practice-areas/project-management/team-working-agreements-instructions.md
           - Templates: practice-areas/project-management/templates.md
           - Training: practice-areas/project-management/pm-training.md
-          - Unanet Tasks and Training Material: practice-areas/project-management/pm-unanet-tasks.md
+          - Unanet tasks and training material: practice-areas/project-management/pm-unanet-tasks.md
       - Project support:
           - Overview: practice-areas/help-desk/helpdesk.md
           - Project support and Agile: practice-areas/help-desk/help-desk-agile.md


### PR DESCRIPTION
We’ve updated the guidebook top navigation to increase the font color contrast and font size. In doing so the space between the labels is smaller, thus reducing the ability to differentiate between the labels. To correct this, we’re changing the navigation labels using words with equivalent meaning and fewer characters. "About CivicActions" changes to "About us".
"Common practices and tools" changes to "Our practices and tools".

<!-- readthedocs-preview civicactions-handbook start -->
----
:books: Documentation preview :books:: https://civicactions-handbook--1113.org.readthedocs.build/en/1113/

<!-- readthedocs-preview civicactions-handbook end -->