### PR TITLE
Add Decap

### DIFF
--- a/.config/codespell-ignore
+++ b/.config/codespell-ignore
@@ -1,1 +1,2 @@
 halp
+COO

--- a/.config/codespell-ignore
+++ b/.config/codespell-ignore
@@ -1,2 +1,2 @@
 halp
-COO
+coo

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,6 @@
-# License
+---
+title: License
+---
 
 ## Creative Commons Attribution 4.0 International Public License
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 ---
+title: CivicActions Guidebook
 hide:
     - navigation
     - toc
 ---
-
-# CivicActions Guidebook
 
 ## <a name="purpose"></a>Guidebook Purpose
 

--- a/about-civicactions/annual-summit.md
+++ b/about-civicactions/annual-summit.md
@@ -1,4 +1,6 @@
-# Annual Summit
+---
+title: Annual Summit
+---
 
 CivicActions gathers together in person once a year at our annual retreat. The location of the retreat varies each year, but we aim to make the location accessible so as many team members as possible can join.
 

--- a/about-civicactions/background-and-history.md
+++ b/about-civicactions/background-and-history.md
@@ -1,4 +1,6 @@
-# Background / History
+---
+title: Background / History
+---
 
 CivicActions, Inc. is a professional services firm delivering agile system development lifecycle services with a focus on free & open source software (FOSS). One of the things that makes us unique is our radical openness. Our largest federal clients in 2016 were the Defense Security Cooperation Agency, Department of Education, Federal Communications Commission, and through our partner Acquia, Department of Justice and Department of Treasury. Our largest Non-Profit client was Cal Poly where we re-built the Digital Democracy Platform and their DevOps pipeline.
 

--- a/about-civicactions/culture.md
+++ b/about-civicactions/culture.md
@@ -1,4 +1,6 @@
-# Culture
+---
+title: Culture
+---
 
 ## Introduction
 

--- a/about-civicactions/diversity-equity-inclusion/affinity-channels.md
+++ b/about-civicactions/diversity-equity-inclusion/affinity-channels.md
@@ -1,4 +1,6 @@
-# Affinity Channels
+---
+title: Affinity Channels
+---
 
 ## What is an affinity channel?
 

--- a/about-civicactions/diversity-equity-inclusion/defining-dei.md
+++ b/about-civicactions/diversity-equity-inclusion/defining-dei.md
@@ -1,4 +1,6 @@
-# Defining diversity, equity, inclusion, and accessibility (DEIA)
+---
+title: Defining diversity, equity, inclusion, and accessibility (DEIA)
+---
 
 ## Diversity
 

--- a/about-civicactions/diversity-equity-inclusion/deia-get-involved.md
+++ b/about-civicactions/diversity-equity-inclusion/deia-get-involved.md
@@ -1,8 +1,10 @@
-# DEIA: Get Involved
+---
+title: "DEIA: Get Involved"
+---
 
 ## [Join](https://docs.google.com/forms/d/1KEwz-rAeRg736rC-vCHU5uEL9ZSo0FesXefQHFN03Rg/edit?usp=sharing) the DEIA Working Group
 
-People are encouraged to apply to become part of the DEIA Working Group. We strive to reflect the diversity we seek to achieve within CivicActions. Approved members are allocated time to work on DEIA issues with the Working Group and receive an additional $500 Professional Development budget to advance their awareness.
+People are encouraged to apply to become part of the DEIA Working Group. We strive to reflect the diversity we seek to achieve within CivicActions. Approved members are allocated time to work on DEIA issues with the Working Group and receive an additional \$500 Professional Development budget to advance their awareness.
 
 ## Join the Conversation
 

--- a/about-civicactions/diversity-equity-inclusion/deia-get-involved.md
+++ b/about-civicactions/diversity-equity-inclusion/deia-get-involved.md
@@ -4,7 +4,7 @@ title: "DEIA: Get Involved"
 
 ## [Join](https://docs.google.com/forms/d/1KEwz-rAeRg736rC-vCHU5uEL9ZSo0FesXefQHFN03Rg/edit?usp=sharing) the DEIA Working Group
 
-People are encouraged to apply to become part of the DEIA Working Group. We strive to reflect the diversity we seek to achieve within CivicActions. Approved members are allocated time to work on DEIA issues with the Working Group and receive an additional \$500 Professional Development budget to advance their awareness.
+People are encouraged to apply to become part of the DEIA Working Group. We strive to reflect the diversity we seek to achieve within CivicActions. Approved members are allocated time to work on DEIA issues with the Working Group and receive an additional $500 Professional Development budget to advance their awareness.
 
 ## Join the Conversation
 

--- a/about-civicactions/diversity-equity-inclusion/purpose.md
+++ b/about-civicactions/diversity-equity-inclusion/purpose.md
@@ -1,4 +1,6 @@
-# Diversity, Equity, Inclusion, and Accessibility (DEIA) at CivicActions
+---
+title: Diversity, Equity, Inclusion, and Accessibility (DEIA) at CivicActions
+---
 
 At CivicActions we have a vision of a world that works for all. We are committed to diversity, equity, inclusion and accessibility in both our team culture and our work on problems that shape civic life.
 

--- a/about-civicactions/diversity-equity-inclusion/resources.md
+++ b/about-civicactions/diversity-equity-inclusion/resources.md
@@ -1,4 +1,6 @@
-# DEIA resources
+---
+title: DEIA resources
+---
 
 Find resources on various DEIA topics, as well as materials developed for and by CivicActions.
 

--- a/about-civicactions/mission-values.md
+++ b/about-civicactions/mission-values.md
@@ -1,4 +1,6 @@
-# Mission, Value Proposition, and Operating Principles
+---
+title: Mission, Value Proposition, and Operating Principles
+---
 
 ## Mission
 

--- a/about-civicactions/our-structurehow-we-are-organized.md
+++ b/about-civicactions/our-structurehow-we-are-organized.md
@@ -1,4 +1,6 @@
-# Organization
+---
+title: Organization
+---
 
 CivicActions is organized into several types of groups.
 

--- a/about-civicactions/our-structuremanagement-ops.md
+++ b/about-civicactions/our-structuremanagement-ops.md
@@ -1,4 +1,6 @@
-# Leadership and management
+---
+title: Leadership and management
+---
 
 Board
 

--- a/about-civicactions/our-structureorg-structure.md
+++ b/about-civicactions/our-structureorg-structure.md
@@ -1,4 +1,6 @@
-# Organizational Structure
+---
+title: Organizational Structure
+---
 
 In 2021 CivicActions undertook a shift from a fairly flat organization that had a small management team, to a matrix organization that introduced new levels of leadership. [This document](https://docs.google.com/document/d/1DU5pPbhMH0_PzkOohvHPknQ-xvQz9CZfUFYD2WNQtpI/edit?usp=sharing) is to serve as a single source of information that includes a summary of current state of organization, links to current org structure and other relevant links, and what is complete and still in-motion.
 

--- a/about-this-guidebook/README.md
+++ b/about-this-guidebook/README.md
@@ -1,4 +1,6 @@
-# About this guidebook
+---
+title: About this guidebook
+---
 
 This guidebook is written by and for all employees of CivicActions. Everyone is encouraged to contribute to continuously improve it.
 

--- a/about-this-guidebook/automatic-checking.md
+++ b/about-this-guidebook/automatic-checking.md
@@ -1,4 +1,6 @@
-# Automatic checking
+---
+title: Automatic checking
+---
 
 We use GitHub Actions CI, a hosted, distributed continuous integration service, to test projects hosted at GitHub. Actions automatically detects when a commit has been pushed to a GitHub repository. Each time this happens, it will try to build the project and run tests to ensure that the commit complies with certain standards. For now, it is primarily concerned with our [markdown](markdown-for-guidebook.md) syntax, and will "fail" if there are errors as specified in the .remarkrc.error file in the root directory in the repo.
 

--- a/about-this-guidebook/editing-the-guidebook.md
+++ b/about-this-guidebook/editing-the-guidebook.md
@@ -1,4 +1,6 @@
-# Editing the guidebook using Git
+---
+title: Editing the guidebook using Git
+---
 
 The guidebook is a collection of markdown files that you can edit in Github.
 

--- a/about-this-guidebook/guidebook-governance.md
+++ b/about-this-guidebook/guidebook-governance.md
@@ -1,4 +1,6 @@
-# Governance
+---
+title: Governance
+---
 
 Any team member with a GitHub account can make [pull requests](editing-the-guidebook.md) to change any part of the guidebook.
 

--- a/about-this-guidebook/markdown-for-guidebook.md
+++ b/about-this-guidebook/markdown-for-guidebook.md
@@ -1,4 +1,6 @@
-# Markdown
+---
+title: Markdown
+---
 
 The guidebook is written in markdown.
 

--- a/about-this-guidebook/reviewing-pull-requests.md
+++ b/about-this-guidebook/reviewing-pull-requests.md
@@ -1,4 +1,6 @@
-# Reviewing pull requests
+---
+title: Reviewing pull requests
+---
 
 All pull requests (PRs) are automatically assigned to a team for a review, based on which part of the guidebook is being edited.
 

--- a/about-this-guidebook/why-guidebook-is-open.md
+++ b/about-this-guidebook/why-guidebook-is-open.md
@@ -4,7 +4,7 @@ title: Why this guidebook is open
 
 Working in the open embodies the [CivicActions culture](../about-civicactions/culture.md). It's how we think and how we want to be known.
 
-We've made our guidebook open and available publically so that:
+We've made our guidebook open and available publicly so that:
 
 -   Current employees and new hires can access it from wherever they are
 -   Potential job candidates can learn what we're about and why it's awesome to work here

--- a/about-this-guidebook/why-guidebook-is-open.md
+++ b/about-this-guidebook/why-guidebook-is-open.md
@@ -1,4 +1,6 @@
-# Why this guidebook is open
+---
+title: Why this guidebook is open
+---
 
 Working in the open embodies the [CivicActions culture](../about-civicactions/culture.md). It's how we think and how we want to be known.
 

--- a/about-this-guidebook/writing-style-guide.md
+++ b/about-this-guidebook/writing-style-guide.md
@@ -1,4 +1,6 @@
-# Writing style
+---
+title: Writing style
+---
 
 We come from different disciplines and levels of familiarity with Agile or technical subjects. Consider your audience when writing content, including how much or little they know about your topic. Writing in plain language with shorter, simpler words and bulleted lists instead of long sentences helps everyone. At the same time, be sure to use specific terms known to those in the same discipline.
 

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -2,7 +2,7 @@ backend:
   name: github
   repo: grugnog/guidebook
   branch: decap
-site_id: 0d7da33c-7b74-499b-bd7f-1b5c9daa1601
+  site_domain: grugnog-guidebook.netlify.app
 publish_mode: editorial_workflow
 media_folder: "assets/images"
 collections:

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -2,6 +2,7 @@ backend:
   name: github
   repo: grugnog/guidebook
   branch: decap
+site_id: 0d7da33c-7b74-499b-bd7f-1b5c9daa1601
 publish_mode: editorial_workflow
 media_folder: "assets/images"
 collections:

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -13,6 +13,11 @@ collections:
     create: true
     nested:
       depth: 100
+    meta:
+      path:
+        widget: string
+        label: "Path"
+        index_file: "README"
     fields:
       - label: "Title"
         name: "title"

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -1,0 +1,47 @@
+backend:
+  name: github
+  repo: grugnog/guidebook
+  branch: decap
+publish_mode: editorial_workflow
+media_folder: "assets/images"
+collections:
+  - &base
+    name: "about-civicactions"
+    folder: "about-civicactions"
+    label: "About CivicActions"
+    label_singular: "About CivicActions page"
+    create: true
+    nested:
+      depth: 100
+    fields:
+      - label: "Title"
+        name: "title"
+        widget: "string"
+      - label: "Body"
+        name: "body"
+        widget: "markdown"
+  - <<: *base
+    name: "employee-benefits"
+    folder: "employee-benefits"
+    label: "Employee benefits"
+    label_singular: "Employee benefits page"
+  - <<: *base
+    name: "company-policies"
+    folder: "company-policies"
+    label: "Company policies"
+    label_singular: "Company policies page"
+  - <<: *base
+    name: "common-practices-tools"
+    folder: "common-practices-tools"
+    label: "Practices and tools"
+    label_singular: "Practices and tools page"
+  - <<: *base
+    name: "practice-areas"
+    folder: "practice-areas"
+    label: "Practice areas"
+    label_singular: "Practice areas page"
+  - <<: *base
+    name: "about-this-guidebook"
+    folder: "about-this-guidebook"
+    label: "About this guidebook"
+    label_singular: "About this guidebook page"

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -2,7 +2,6 @@ backend:
   name: github
   repo: grugnog/guidebook
   branch: decap
-  site_domain: grugnog-guidebook.netlify.app
 publish_mode: editorial_workflow
 media_folder: "assets/images"
 collections:

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -50,3 +50,17 @@ collections:
     folder: "about-this-guidebook"
     label: "About this guidebook"
     label_singular: "About this guidebook page"
+  # One-off for README page.
+  - name: "top-level"
+    label: "Top level"
+    files:
+      - label: "Home / README"
+        name: "readme"
+        file: "README.md"
+        fields:
+          - label: "Title"
+            name: "title"
+            widget: "string"
+          - label: "Body"
+            name: "body"
+            widget: "markdown"

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -2,6 +2,7 @@ backend:
   name: github
   repo: grugnog/guidebook
   branch: decap
+  base_url: https://v1.netlify-oauth.app.civicactions.net
 publish_mode: editorial_workflow
 media_folder: "assets/images"
 collections:

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -1,7 +1,7 @@
 backend:
   name: github
-  repo: grugnog/guidebook
-  branch: decap
+  repo: civicactions/guidebook
+  branch: master
   base_url: https://v1.netlify-oauth.app.civicactions.net
 publish_mode: editorial_workflow
 media_folder: "assets/images"

--- a/admin/index.html
+++ b/admin/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex" />
+    <title>Content Manager</title>
+  </head>
+  <body>
+    <!-- Include the script that builds the page and powers Decap CMS -->
+    <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
+    <script>
+      CMS.registerRemarkPlugin({
+        settings: {
+          listItemIndent: "tab",
+          bullet: "-",
+          strong: "*",
+          emphasis: "_",
+          fences: true,
+        },
+      });
+    </script>
+  </body>
+</html>

--- a/common-practices-tools/agile/agile-overview.md
+++ b/common-practices-tools/agile/agile-overview.md
@@ -1,4 +1,6 @@
-# Agile Overview
+---
+title: Agile Overview
+---
 
 CivicActions uses Agile practices.
 

--- a/common-practices-tools/agile/agile-practices.md
+++ b/common-practices-tools/agile/agile-practices.md
@@ -1,6 +1,8 @@
-We recommend using this documentation in combination with the [CivicActions project playbook](https://trello.com/b/qyI4wa18/template-civicactions-project-playbook), which maps out an ideal Agile project lifecycle.
+---
+title: Sprint Cycle
+---
 
-# Sprint Cycle
+We recommend using this documentation in combination with the [CivicActions project playbook](https://trello.com/b/qyI4wa18/template-civicactions-project-playbook), which maps out an ideal Agile project lifecycle.
 
 At CivicActions, the most common approach for accomplishing large-scale work is the use of a Scrum sprint cycle.
 

--- a/common-practices-tools/agile/backlog-refinement.md
+++ b/common-practices-tools/agile/backlog-refinement.md
@@ -1,4 +1,6 @@
-# Backlog Refinement
+---
+title: Backlog Refinement
+---
 
 ## What it is
 

--- a/common-practices-tools/agile/daily-scrum-calls.md
+++ b/common-practices-tools/agile/daily-scrum-calls.md
@@ -1,4 +1,6 @@
-# Daily Scrum Calls
+---
+title: Daily Scrum Calls
+---
 
 ## What it is
 

--- a/common-practices-tools/agile/sprint-cycle.md
+++ b/common-practices-tools/agile/sprint-cycle.md
@@ -1,4 +1,6 @@
-# Sprint Cycle
+---
+title: Sprint Cycle
+---
 
 ## Introduction
 

--- a/common-practices-tools/agile/sprint-demo.md
+++ b/common-practices-tools/agile/sprint-demo.md
@@ -1,4 +1,6 @@
-# Sprint Demo
+---
+title: Sprint Demo
+---
 
 ## What it is
 

--- a/common-practices-tools/agile/sprint-planning-meetings.md
+++ b/common-practices-tools/agile/sprint-planning-meetings.md
@@ -1,4 +1,6 @@
-# Sprint Planning Meetings
+---
+title: Sprint Planning Meetings
+---
 
 ## What it is
 

--- a/common-practices-tools/agile/sprint-retrospectives.md
+++ b/common-practices-tools/agile/sprint-retrospectives.md
@@ -1,4 +1,6 @@
-# Sprint Retrospectives
+---
+title: Sprint Retrospectives
+---
 
 ## What it is
 

--- a/common-practices-tools/agile/tickets-cards.md
+++ b/common-practices-tools/agile/tickets-cards.md
@@ -1,4 +1,6 @@
-# How to Create Tickets
+---
+title: How to Create Tickets
+---
 
 This may also be best learned during a project (on a project-by-project basis)
 

--- a/common-practices-tools/balance-scores.md
+++ b/common-practices-tools/balance-scores.md
@@ -1,4 +1,6 @@
-# Balance scores
+---
+title: Balance scores
+---
 
 ## Talking points
 

--- a/common-practices-tools/best-practices-for-managers-and-team-members.md
+++ b/common-practices-tools/best-practices-for-managers-and-team-members.md
@@ -1,4 +1,6 @@
-# Best practices for managers and team members
+---
+title: Best practices for managers and team members
+---
 
 The following are suggestions for activities that can be helpful for managers, team members, and project leads. Only some of these will be necessary for some circumstances. Managers and project leads should use their discretion to determine the appropriate methods and the cadence of these activities.
 

--- a/common-practices-tools/gold-star-program.md
+++ b/common-practices-tools/gold-star-program.md
@@ -1,4 +1,6 @@
-# Gold Star Program
+---
+title: Gold Star Program
+---
 
 "Gold Stars" are small acts of recognition and acknowledgment for fellow team members. When someone does something outstanding, "over and above," or otherwise deserves recognition, give them a "Gold Star" by Slacking a note to the team explaining what the commendation is for.
 

--- a/common-practices-tools/security/awareness.md
+++ b/common-practices-tools/security/awareness.md
@@ -1,4 +1,6 @@
-# Security Awareness and Tools
+---
+title: Security Awareness and Tools
+---
 
 This is an appendix to the [CivicActions Security Policy](../../company-policies/security.md) containing details that can and should be updated regularly as new technologies or patterns of use develop, with a goal of providing team members the best tools with which to maintain the security of company confidential and personal information.
 

--- a/common-practices-tools/security/contingency-plan.md
+++ b/common-practices-tools/security/contingency-plan.md
@@ -1,4 +1,6 @@
-# CivicActions Common Contingency Plan
+---
+title: CivicActions Common Contingency Plan
+---
 
 ## Table of Contents
 

--- a/common-practices-tools/security/drupal-rmf-support.md
+++ b/common-practices-tools/security/drupal-rmf-support.md
@@ -1,4 +1,6 @@
-# Supporting RMF Controls with Drupal Tools & Practices
+---
+title: Supporting RMF Controls with Drupal Tools & Practices
+---
 
 | _RMF_   | _Control Title_                       | _Drupal Tool / Practices_                                                                | _Notes_                     |
 | ------- | ------------------------------------- | ---------------------------------------------------------------------------------------- | --------------------------- |

--- a/common-practices-tools/security/encryption.md
+++ b/common-practices-tools/security/encryption.md
@@ -1,4 +1,6 @@
-# Protecting Your Privacy with Encryption
+---
+title: Protecting Your Privacy with Encryption
+---
 
 The following offers a brief and necessarily incomplete overview of a few FOSS tools, several of which employ encryption, that you can download and install to enhance the privacy of your interactions online.
 

--- a/common-practices-tools/security/incident-response-checklist.md
+++ b/common-practices-tools/security/incident-response-checklist.md
@@ -1,4 +1,6 @@
-# CivicActions Security Incident Response Procedure Checklist
+---
+title: CivicActions Security Incident Response Procedure Checklist
+---
 
 For more details on any part of the checklist, see the [Security Incident Response Plan](incident-response-plan.md).
 

--- a/common-practices-tools/security/incident-response-plan.md
+++ b/common-practices-tools/security/incident-response-plan.md
@@ -1,4 +1,6 @@
-# CivicActions Security Incident Response Procedures
+---
+title: CivicActions Security Incident Response Procedures
+---
 
 ## Table of Contents
 

--- a/common-practices-tools/security/incidents.md
+++ b/common-practices-tools/security/incidents.md
@@ -1,4 +1,6 @@
-# Security Incidents
+---
+title: Security Incidents
+---
 
 Something went "bump" in the night (or the day)? This document explains what to do when you need to report a potential security incident.
 

--- a/common-practices-tools/security/yubikey/README.md
+++ b/common-practices-tools/security/yubikey/README.md
@@ -1,4 +1,6 @@
-# Using your YubiKey
+---
+title: Using your YubiKey
+---
 
 Notes on installing and setting up your _YubiKey 4_ for various platforms and applications.
 

--- a/common-practices-tools/security/yubikey/linux.md
+++ b/common-practices-tools/security/yubikey/linux.md
@@ -1,4 +1,6 @@
-# YubiKey Support for GNU/Linux
+---
+title: YubiKey Support for GNU/Linux
+---
 
 This is the GNU/Linux specific documentation for [YubiKey](README.md).
 

--- a/common-practices-tools/security/yubikey/macosx.md
+++ b/common-practices-tools/security/yubikey/macosx.md
@@ -1,4 +1,6 @@
-# YubiKey Support for Mac OS X
+---
+title: YubiKey Support for Mac OS X
+---
 
 This is the Mac OS X specific documentation for [YubiKey](README.md).
 

--- a/common-practices-tools/skills-base.md
+++ b/common-practices-tools/skills-base.md
@@ -1,4 +1,6 @@
-# Skills Base
+---
+title: Skills Base
+---
 
 Skills Base is a tool that lets us catalog our skills across the team and track who has what skills, interests, and qualifications. This is useful in many ways:
 

--- a/common-practices-tools/software-and-support/email.md
+++ b/common-practices-tools/software-and-support/email.md
@@ -1,4 +1,6 @@
-# civicactions.com email
+---
+title: civicactions.com email
+---
 
 ## Internal lists
 

--- a/common-practices-tools/software-and-support/github.md
+++ b/common-practices-tools/software-and-support/github.md
@@ -1,4 +1,6 @@
-# GitHub
+---
+title: GitHub
+---
 
 ## About GitHub
 

--- a/common-practices-tools/software-and-support/google-calendar.md
+++ b/common-practices-tools/software-and-support/google-calendar.md
@@ -1,4 +1,6 @@
-# Google calendar
+---
+title: Google calendar
+---
 
 ## Overview
 

--- a/common-practices-tools/software-and-support/google-docs.md
+++ b/common-practices-tools/software-and-support/google-docs.md
@@ -1,4 +1,6 @@
-# Google Docs
+---
+title: Google Docs
+---
 
 -   Google Docs allows you to create and share a variety of documents such as text documents, spreadsheets, presentations, and forms.
 -   Google Docs should be shared with your CivicActions email account

--- a/common-practices-tools/software-and-support/google-meet.md
+++ b/common-practices-tools/software-and-support/google-meet.md
@@ -1,4 +1,6 @@
-# Google Meet (formerly Google Hangouts)
+---
+title: Google Meet (formerly Google Hangouts)
+---
 
 ## Google Meet v Zoom
 

--- a/common-practices-tools/software-and-support/jira.md
+++ b/common-practices-tools/software-and-support/jira.md
@@ -1,4 +1,6 @@
-# Jira
+---
+title: Jira
+---
 
 The following is a general overview of Jira, but each project may have specific setups or workflows that differ.
 

--- a/common-practices-tools/software-and-support/markdown.md
+++ b/common-practices-tools/software-and-support/markdown.md
@@ -1,4 +1,6 @@
-# Markdown
+---
+title: Markdown
+---
 
 ## What is it?
 

--- a/common-practices-tools/software-and-support/slack.md
+++ b/common-practices-tools/software-and-support/slack.md
@@ -1,4 +1,6 @@
-# Slack
+---
+title: Slack
+---
 
 ## Basics
 

--- a/common-practices-tools/software-and-support/support.md
+++ b/common-practices-tools/software-and-support/support.md
@@ -1,4 +1,6 @@
-# Internal support
+---
+title: Internal support
+---
 
 Note: this is the process for requesting internal support. We also have a [help desk practice area](../../practice-areas/help-desk/helpdesk.md) comprised of teams providing helpdesk support services on client projects.
 

--- a/common-practices-tools/software-and-support/text-editors.md
+++ b/common-practices-tools/software-and-support/text-editors.md
@@ -1,4 +1,6 @@
-# Text editors
+---
+title: Text editors
+---
 
 ## Popular Editors at CivicActions
 

--- a/common-practices-tools/software-and-support/trello.md
+++ b/common-practices-tools/software-and-support/trello.md
@@ -1,4 +1,6 @@
-# Trello
+---
+title: Trello
+---
 
 ## Overview
 

--- a/common-practices-tools/software-and-support/zoom.md
+++ b/common-practices-tools/software-and-support/zoom.md
@@ -1,4 +1,6 @@
-# Zoom
+---
+title: Zoom
+---
 
 ## Basic Overview
 

--- a/common-practices-tools/telephone.md
+++ b/common-practices-tools/telephone.md
@@ -1,4 +1,6 @@
-# Telephone Use
+---
+title: Telephone Use
+---
 
 -   There are times when a phone call in may also be necessary, such as when Wi-Fi is not available or to call in to Zoom
 -   Don't rely on speaker feature, but have a headset handy

--- a/company-policies/annual-review-process.md
+++ b/company-policies/annual-review-process.md
@@ -1,4 +1,6 @@
-# Annual performance review
+---
+title: Annual performance review
+---
 
 CivicActions uses Culture Amp to administer annual reviews. Culture Amp offers asynchronous, scalable review processes, including self reflection, peer feedback, and manager feedback.
 

--- a/company-policies/anti-harassment-policies.md
+++ b/company-policies/anti-harassment-policies.md
@@ -1,8 +1,7 @@
 ---
+title: Policy Against Proscribed Harassment and Discrimination
 updated: June 22, 2018
 ---
-
-# Policy Against Proscribed Harassment and Discrimination
 
 _This policy was taken directly from the TriNet handbook as of June 2018._
 

--- a/company-policies/code-of-conduct.md
+++ b/company-policies/code-of-conduct.md
@@ -1,8 +1,7 @@
 ---
+title: CivicActions Code of Conduct
 updated: October 30, 2020
 ---
-
-# CivicActions Code of Conduct
 
 ## General Guidelines
 

--- a/company-policies/covid19-safety.md
+++ b/company-policies/covid19-safety.md
@@ -1,4 +1,6 @@
-# COVID-19 Safety and Vaccine policy
+---
+title: COVID-19 Safety and Vaccine policy
+---
 
 Employees are not required to provide proof of vaccinations, but we follow CDC recommendations and standards for work events where more than one person is present. CivicActions follows guidance provided by CDC for in person events. Specifically, individuals who have recently tested positive for COVID-19, are showing symptoms of COVID-19 and are waiting on test results, may not attend in-person events. Individuals who have recently been exposed to someone with COVID-19 should follow CDC recommendations before attending any in person events.
 

--- a/company-policies/employment/leaving-civicactions.md
+++ b/company-policies/employment/leaving-civicactions.md
@@ -1,4 +1,6 @@
-# Leaving CivicActions
+---
+title: Leaving CivicActions
+---
 
 ## At-Will Employment
 

--- a/company-policies/employment/us/employment.md
+++ b/company-policies/employment/us/employment.md
@@ -1,4 +1,6 @@
-# Employment
+---
+title: Employment
+---
 
 ## TriNet
 

--- a/company-policies/employment/us/introductory-period.md
+++ b/company-policies/employment/us/introductory-period.md
@@ -1,4 +1,6 @@
-# Introductory Period
+---
+title: Introductory Period
+---
 
 Upon joining CivicActions, team members enter into a ninety day introductory period. During this timeframe, team members will learn and engage with CivicActions culture and values, meet their team, become acclimated to our working style and learn the tasks and responsibilities of their role. We have an extensive interview process that supports ensuring we are hiring for fit along the lines of good communication skills, remote work capabilities, technical skills, and more; but this period also allows us to ensure that there is alignment once new team members get here.
 

--- a/company-policies/employment/workplace-guidelines.md
+++ b/company-policies/employment/workplace-guidelines.md
@@ -1,8 +1,7 @@
 ---
+title: Workplace guidelines
 updated: May 9, 2017
 ---
-
-# Workplace guidelines
 
 ## Hours of work
 

--- a/company-policies/expenses.md
+++ b/company-policies/expenses.md
@@ -1,8 +1,7 @@
 ---
+title: Expenses
 updated: February 24, 2023
 ---
-
-# Expenses
 
 Employees should submit expense reports within five (5) business days after returning from a business trip or after incurring the expense(s). Expense reports submitted more than 30 days late may not be processed and paid without approval from the CFO. Outstanding expense reports are justification for CivicActions to withhold travel advances for subsequent trips.
 
@@ -47,7 +46,7 @@ IMPORTANT NOTE: when your expense Request is approved, Unanet automatically chan
 -   Consider AirBnB instead of hotels. If you are unsure of how many people can attend, getting a slightly larger AirBnB ahead of time is normally better than waiting and getting an AirBnB or hotel rooms last minute.
 -   Your Project Manager and the Officer Manager will provide information about what is or isn't reimbursable. For example, if you prefer first class for a flight or want to add a leg for a vacation, then that wouldn't be reimbursable but the amount for an economy class return would.
 -   Reduce your footprint when possible and use public transit or shared Lyft Lines instead of single occupancy rides.
--   If you are purchasing multiple "under $50" items in a short timespan, please consider that a single purchase and request approval first.
+-   If you are purchasing multiple "under \$50" items in a short timespan, please consider that a single purchase and request approval first.
 
 ### Travel expenses
 

--- a/company-policies/expenses.md
+++ b/company-policies/expenses.md
@@ -46,7 +46,7 @@ IMPORTANT NOTE: when your expense Request is approved, Unanet automatically chan
 -   Consider AirBnB instead of hotels. If you are unsure of how many people can attend, getting a slightly larger AirBnB ahead of time is normally better than waiting and getting an AirBnB or hotel rooms last minute.
 -   Your Project Manager and the Officer Manager will provide information about what is or isn't reimbursable. For example, if you prefer first class for a flight or want to add a leg for a vacation, then that wouldn't be reimbursable but the amount for an economy class return would.
 -   Reduce your footprint when possible and use public transit or shared Lyft Lines instead of single occupancy rides.
--   If you are purchasing multiple "under \$50" items in a short timespan, please consider that a single purchase and request approval first.
+-   If you are purchasing multiple "under $50" items in a short timespan, please consider that a single purchase and request approval first.
 
 ### Travel expenses
 

--- a/company-policies/health-safety-security.md
+++ b/company-policies/health-safety-security.md
@@ -1,4 +1,6 @@
-# Health, Safety and Security
+---
+title: Health, Safety and Security
+---
 
 ## Workers' Compensation
 

--- a/company-policies/new-hire-orientation/bookmarks.md
+++ b/company-policies/new-hire-orientation/bookmarks.md
@@ -1,4 +1,6 @@
-# Bookmarks
+---
+title: Bookmarks
+---
 
 Links to websites we use regularly.
 

--- a/company-policies/new-hire-orientation/buddy-program.md
+++ b/company-policies/new-hire-orientation/buddy-program.md
@@ -1,4 +1,6 @@
-# Buddy Program
+---
+title: Buddy Program
+---
 
 ## The Role of the Buddy
 

--- a/company-policies/new-hire-orientation/elevator-pitch.md
+++ b/company-policies/new-hire-orientation/elevator-pitch.md
@@ -1,4 +1,6 @@
-# CivicActions' Elevator Pitch
+---
+title: CivicActions' Elevator Pitch
+---
 
 Are you prepared for the "so, what does _your_ company do" questions? Having an elevator pitch in mind is useful, not just for conferences, but also for every day networking.
 

--- a/company-policies/new-hire-orientation/intro-open-source.md
+++ b/company-policies/new-hire-orientation/intro-open-source.md
@@ -1,4 +1,6 @@
-# Free and Open Source Software (FOSS)
+---
+title: Free and Open Source Software (FOSS)
+---
 
 ## What is free and open source software?
 

--- a/company-policies/new-hire-orientation/meetings-and-meeting-tools.md
+++ b/company-policies/new-hire-orientation/meetings-and-meeting-tools.md
@@ -1,4 +1,6 @@
-# Meetings
+---
+title: Meetings
+---
 
 ## Your Own Events
 

--- a/company-policies/new-hire-orientation/people-planning.md
+++ b/company-policies/new-hire-orientation/people-planning.md
@@ -1,4 +1,6 @@
-# What is people planning?
+---
+title: What is people planning?
+---
 
 At CivicActions, we talk about people planning, not resource planning. People planning should share the request, the impact, the risks, and the constraints. It's important that we be transparent about why someone is the best fit for staffing a project. [Review the people planning presentation slidedeck](https://docs.google.com/presentation/d/1r-vcHcygxP5x0B7ZqUy1DVnlH7H3Fk7HjWVFS_LnzbU).
 

--- a/company-policies/new-hire-orientation/security-training.md
+++ b/company-policies/new-hire-orientation/security-training.md
@@ -1,4 +1,6 @@
-# Security for Everyone
+---
+title: Security for Everyone
+---
 
 ## Security Policy
 

--- a/company-policies/new-hire-orientation/training-resources.md
+++ b/company-policies/new-hire-orientation/training-resources.md
@@ -1,4 +1,6 @@
-# Training Resources
+---
+title: Training Resources
+---
 
 As an CivicActions team member, you have access to these online training resources.
 

--- a/company-policies/new-hire-orientation/video-call-best-practices.md
+++ b/company-policies/new-hire-orientation/video-call-best-practices.md
@@ -1,4 +1,6 @@
-# Video Call Best Practices
+---
+title: Video Call Best Practices
+---
 
 -   Be on time - please! Seconds matter.
 -   Add a photo to your account, so it shows up if your camera is off.

--- a/company-policies/new-hire-orientation/virtual-workplace-basics.md
+++ b/company-policies/new-hire-orientation/virtual-workplace-basics.md
@@ -1,4 +1,6 @@
-# Virtual Workplace Basics
+---
+title: Virtual Workplace Basics
+---
 
 ## Introduction
 

--- a/company-policies/new-hire-orientation/welcome.md
+++ b/company-policies/new-hire-orientation/welcome.md
@@ -1,4 +1,6 @@
-# New hire orientation
+---
+title: New hire orientation
+---
 
 ## Welcome to CivicActions!
 

--- a/company-policies/performance-management.md
+++ b/company-policies/performance-management.md
@@ -1,8 +1,7 @@
 ---
+title: Performance Management
 updated: August 19, 2022
 ---
-
-# Performance Management
 
 CivicActions takes a hands-on approach to supporting our team members' performance and success. Following Agile methodology, CivicActions, including its managers, strives to give team members feedback on a continual basis through the project retrospective process, regular check-ins with managers, scrum calls, coworking and other methods of feedback. CivicActions cares about our team members' success and has developed practices to help team members succeed. CivicActions is continually looking to improve how we work with team members to build beneficial relationships, manage performance, and support team members' success.
 When a team member does not meet the expectation of their role, CivicActions prefers to initially address performance issues using informal feedback (either orally or in writing) from a project lead or a manager. If performance issues are not improved based on informal feedback, a manager may have additional conversations with the team member about the issue and expectations for improving, and may provide written feedback documenting the performance issues and the expectations.

--- a/company-policies/security.md
+++ b/company-policies/security.md
@@ -1,8 +1,7 @@
 ---
+title: CivicActions Information Security Policy
 version: 1.1.4
 ---
-
-# CivicActions Information Security Policy
 
 CivicActions has established the following policy to safeguard the security, confidentiality, availability and integrity of CivicActions data, as well as that of our personnel, clients and client website users. All CivicActions employees and contractors are expected to accept and abide by this policy. This policy will be reviewed and updated from time to time. If you have questions or comments about this policy please contact your supervisor. We invite your feedback.
 

--- a/company-policies/timesheets.md
+++ b/company-policies/timesheets.md
@@ -1,4 +1,6 @@
-# Unanet
+---
+title: Unanet
+---
 
 ## Introduction
 

--- a/company-policies/travel-time-tracking-and-expenses.md
+++ b/company-policies/travel-time-tracking-and-expenses.md
@@ -1,4 +1,6 @@
-# Travel expenses and billing
+---
+title: Travel expenses and billing
+---
 
 CivicActions will reimburse team members for travel expenses that are required for work. This includes traveling to client locations. For onsite employees, travel expenses are not reimbursed to their regular work location.
 

--- a/employee-benefits/canada-benefits-policy.md
+++ b/employee-benefits/canada-benefits-policy.md
@@ -1,4 +1,6 @@
-# Benefits
+---
+title: Benefits
+---
 
 Time off under this policy is not being provided in addition to any pre-existing vacation, personal time, or sick leave policy, which are now superseded by this policy.
 

--- a/employee-benefits/canada-tech-stipend.md
+++ b/employee-benefits/canada-tech-stipend.md
@@ -1,8 +1,7 @@
 ---
+title: Technology Stipend Policy (Canadian Employees)
 updated: March 29 2021
 ---
-
-# Technology Stipend Policy (Canadian Employees)
 
 As part of CivicActions commitment to work/life balance and our movement toward greater workplace equity, it is aligned with our values to provide "Technology Stipends" to our employees to reimburse them for necessary expenditures including reasonable costs that are common for all employees at CivicActions. To avoid burdensome paperwork and to give employees flexibility in determining how best meet personal preferences in their work environment, CivicActions will pay to each employee the Technology Stipend once a year in one lump sum.
 
@@ -14,7 +13,7 @@ As part of CivicActions commitment to work/life balance and our movement toward 
     1. The Annual Eligibility Date for Eligible Team Members who have been with CivicActions for more than one year since their last hire date is the annual anniversary of their last hire date.
     1. The Annual Eligibility Date for Team Members who are hired by CivicActions after April 1, 2021 and have been with CivicActions for less then a year is the last day of the ninety-day Introductory Period.
 
--   "Payment Amount" - The Payment Amount as of April 1, 2021 is $1287.00 CAD. The amount will be reviewed annually.
+-   "Payment Amount" - The Payment Amount as of April 1, 2021 is \$1287.00 CAD. The amount will be reviewed annually.
 
 ## Policy
 

--- a/employee-benefits/employee-referral-bonus.md
+++ b/employee-benefits/employee-referral-bonus.md
@@ -1,8 +1,7 @@
 ---
+title: CivicActions Employee Referral Bonus Program
 updated: March 18, 2022
 ---
-
-# CivicActions Employee Referral Bonus Program
 
 CivicActions is always looking for good people, and you can help. Research has shown that new hires who come into a company through employee referrals are excellent contributors, stay with the company longer, and are more cost-effective recruits.
 

--- a/employee-benefits/on-call-stipend.md
+++ b/employee-benefits/on-call-stipend.md
@@ -1,8 +1,7 @@
 ---
+title: On-call stipends
 updated: September 11, 2020
 ---
-
-# On-call stipends
 
 ## Purpose
 

--- a/employee-benefits/on-call-stipend.md
+++ b/employee-benefits/on-call-stipend.md
@@ -29,7 +29,7 @@ CivicActions recognizes that being on-call outside of normal business hours take
 
 ## Payment
 
--   The on-call stipend amount is \$2000 per fiscal quarter (effective starting July, 1, 2020).
+-   The on-call stipend amount is $2000 per fiscal quarter (effective starting July, 1, 2020).
 -   This amount is prorated by day for people joining/leaving the on-call rotation mid-quarter.
 -   This amount is prorated for part-time employees.
 -   The stipend is paid quarterly after the conclusion of the fiscal quarter.

--- a/employee-benefits/professional-development.md
+++ b/employee-benefits/professional-development.md
@@ -1,4 +1,6 @@
-# Professional development at CivicActions
+---
+title: Professional development at CivicActions
+---
 
 CivicActions recognizes the importance of individual professional development for all team members. We value professional development for a number of reasons:
 

--- a/employee-benefits/us-benefits-policy.md
+++ b/employee-benefits/us-benefits-policy.md
@@ -1,4 +1,6 @@
-# Benefits
+---
+title: Benefits
+---
 
 Time off under this policy is not being provided in addition to any pre-existing vacation, personal time, or sick leave policy, which are now superseded by this policy.
 

--- a/employee-benefits/us-compensation.md
+++ b/employee-benefits/us-compensation.md
@@ -1,8 +1,7 @@
 ---
+title: Compensation
 updated: May 9, 2017
 ---
-
-# Compensation
 
 ## Pay Periods
 

--- a/employee-benefits/us-tech-stipend.md
+++ b/employee-benefits/us-tech-stipend.md
@@ -1,8 +1,7 @@
 ---
+title: Technology Stipend Policy (US Employees)
 updated: March 29 2021
 ---
-
-# Technology Stipend Policy (US Employees)
 
 As part of CivicActions commitment to work/life balance and our movement toward greater workplace equity, it is aligned with our values to provide "Technology Stipends" to our employees to reimburse them for necessary expenditures including reasonable costs that are common for all employees at CivicActions. To avoid burdensome paperwork and to give employees flexibility in determining how best meet personal preferences in their work environment, CivicActions will pay to each employee the Technology Stipend once a year in one lump sum. Since the tech stipend is a reimbursement of expenses it is not subject to income tax in the United States.
 

--- a/practice-areas/about-practice-areas.md
+++ b/practice-areas/about-practice-areas.md
@@ -1,4 +1,6 @@
-# Practice Areas
+---
+title: Practice Areas
+---
 
 Practice areas are self-organized groups oriented around a specific practice or craft to foster learning, continuous improvement and cross-pollination of ideas and best practice across the company.
 

--- a/practice-areas/accessibility/accessibility-how-to.md
+++ b/practice-areas/accessibility/accessibility-how-to.md
@@ -1,5 +1,5 @@
 ---
-title: Accessibility: How To
+title: "Accessibility: How To"
 ---
 
 ## Resources for learning how to test the accessibility of our applications

--- a/practice-areas/accessibility/accessibility-how-to.md
+++ b/practice-areas/accessibility/accessibility-how-to.md
@@ -1,4 +1,6 @@
-# Accessibility: How To
+---
+title: Accessibility: How To
+---
 
 ## Resources for learning how to test the accessibility of our applications
 

--- a/practice-areas/accessibility/accessibility-practice-area.md
+++ b/practice-areas/accessibility/accessibility-practice-area.md
@@ -1,4 +1,6 @@
-# Accessibility Practice Area
+---
+title: Accessibility Practice Area
+---
 
 CivicActions Accessibility is an open project primarily developed by CivicActions team members. We work to implement our [Accessibility Pledge](https://accessibility.civicactions.com/posts/CivicActions-Accessibility-Pledge) and build a robust culture has internalized accessibility.
 

--- a/practice-areas/design-and-research/audiences-and-outcomes-guide.md
+++ b/practice-areas/design-and-research/audiences-and-outcomes-guide.md
@@ -1,4 +1,6 @@
-# Audiences and Outcomes Guide
+---
+title: Audiences and Outcomes Guide
+---
 
 ## What it is
 

--- a/practice-areas/design-and-research/content-audit-guide.md
+++ b/practice-areas/design-and-research/content-audit-guide.md
@@ -1,4 +1,6 @@
-# Content Audit Guide
+---
+title: Content Audit Guide
+---
 
 ## What it is
 

--- a/practice-areas/design-and-research/content-modeling-guide.md
+++ b/practice-areas/design-and-research/content-modeling-guide.md
@@ -1,4 +1,6 @@
-# Content Modeling Guide
+---
+title: Content Modeling Guide
+---
 
 ## What it is
 

--- a/practice-areas/design-and-research/design-research-methods.md
+++ b/practice-areas/design-and-research/design-research-methods.md
@@ -1,4 +1,6 @@
-# Design and research methods
+---
+title: Design and research methods
+---
 
 ## Research methods
 

--- a/practice-areas/design-and-research/stakeholder-interviews-guide.md
+++ b/practice-areas/design-and-research/stakeholder-interviews-guide.md
@@ -1,4 +1,6 @@
-# Stakeholder Interviews Guide
+---
+title: Stakeholder Interviews Guide
+---
 
 ## What it is
 

--- a/practice-areas/design-and-research/story-mapping-guide.md
+++ b/practice-areas/design-and-research/story-mapping-guide.md
@@ -1,4 +1,6 @@
-# Story Mapping Guide
+---
+title: Story Mapping Guide
+---
 
 ## What it is
 

--- a/practice-areas/design-and-research/usability-testing-guide.md
+++ b/practice-areas/design-and-research/usability-testing-guide.md
@@ -1,4 +1,6 @@
-# Usability Testing Guide
+---
+title: Usability Testing Guide
+---
 
 ## What it is
 

--- a/practice-areas/design-and-research/user-personas-guide.md
+++ b/practice-areas/design-and-research/user-personas-guide.md
@@ -1,4 +1,6 @@
-# User Personas Guide
+---
+title: User Personas Guide
+---
 
 ## What it is
 

--- a/practice-areas/engineering/accessibility.md
+++ b/practice-areas/engineering/accessibility.md
@@ -1,4 +1,6 @@
-# Accessibility
+---
+title: Accessibility
+---
 
 We implement Section 508 standards and WCAG compliant websites so that people with all types of disabilities, whether it be physical, mental, or visual impairment, have access to our sites.
 

--- a/practice-areas/engineering/drupal-developer-tips-for-getting-the-most-out-of-open-source.md
+++ b/practice-areas/engineering/drupal-developer-tips-for-getting-the-most-out-of-open-source.md
@@ -1,4 +1,6 @@
-# Drupal Developer Tips for Getting the Most out of Open Source
+---
+title: Drupal Developer Tips for Getting the Most out of Open Source
+---
 
 _This was originally a blog post on the CivicActions site authored by [Nedjo Rogers](https://nedjo.ca/) ([d.o](https://www.drupal.org/u/nedjo)) on November 19, 2008._
 

--- a/practice-areas/engineering/drupal-developer-tips-for-getting-the-most-out-of-open-source.md
+++ b/practice-areas/engineering/drupal-developer-tips-for-getting-the-most-out-of-open-source.md
@@ -2,7 +2,7 @@
 title: Drupal Developer Tips for Getting the Most out of Open Source
 ---
 
-_This was originally a blog post on the CivicActions site authored by [Nedjo Rogers](https://nedjo.ca/) ([d.o](https://www.drupal.org/u/nedjo)) on November 19, 2008._
+Note: _This was originally a blog post on the CivicActions site authored by [Nedjo Rogers](https://nedjo.ca/) ([d.o](https://www.drupal.org/u/nedjo)) on November 19, 2008._
 
 I [recently suggested](most-important-decision-in-developing-a-drupal-site-contributed-vs-custom-development.md) that the way we approach new development is the most important factor in determining the long term value of our work. But just how can developers using Drupal make the most of open source by ensuring that participating and contributing is an essential part of our daily workflow? Here are some practical tips that come out of our experience at CivicActions and that can guide you in deciding how to approach new development to get the full benefit of open source. Read on as well for a discussion of patching vs. hacking vs. forking and of how to get attention for your patches.
 

--- a/practice-areas/engineering/drupal-practice-area.md
+++ b/practice-areas/engineering/drupal-practice-area.md
@@ -1,4 +1,6 @@
-# Drupal Practice Area
+---
+title: Drupal Practice Area
+---
 
 Drupal is a CivicActions engineering-focused [Practice Areas](../about-practice-areas.md). We use the [#engineering-drupal](https://civicactions.slack.com/archives/C0ASJ7C8P) Slack channel and have monthly calls.
 

--- a/practice-areas/engineering/engineering-calls.md
+++ b/practice-areas/engineering/engineering-calls.md
@@ -1,4 +1,6 @@
-# Engineering
+---
+title: Engineering
+---
 
 @todo section intro
 

--- a/practice-areas/engineering/git.md
+++ b/practice-areas/engineering/git.md
@@ -1,4 +1,6 @@
-# Git
+---
+title: Git
+---
 
 ## Git overview
 

--- a/practice-areas/engineering/most-important-decision-in-developing-a-drupal-site-contributed-vs-custom-development.md
+++ b/practice-areas/engineering/most-important-decision-in-developing-a-drupal-site-contributed-vs-custom-development.md
@@ -1,4 +1,8 @@
-# The Most Important Decision In Developing A Drupal Site: Contributed Vs. Custom Development
+---
+header:
+    "The Most Important Decision In Developing A Drupal Site: Contributed Vs.
+    Custom Development"
+---
 
 _This was originally a blog post on the CivicActions site authored by [Nedjo Rogers](https://nedjo.ca/) ([d.o](https://www.drupal.org/u/nedjo)) on November 19, 2008._
 

--- a/practice-areas/engineering/most-important-decision-in-developing-a-drupal-site-contributed-vs-custom-development.md
+++ b/practice-areas/engineering/most-important-decision-in-developing-a-drupal-site-contributed-vs-custom-development.md
@@ -4,7 +4,7 @@ header:
     Custom Development"
 ---
 
-_This was originally a blog post on the CivicActions site authored by [Nedjo Rogers](https://nedjo.ca/) ([d.o](https://www.drupal.org/u/nedjo)) on November 19, 2008._
+Note: _This was originally a blog post on the CivicActions site authored by [Nedjo Rogers](https://nedjo.ca/) ([d.o](https://www.drupal.org/u/nedjo)) on November 19, 2008._
 
 When developing in Drupal, should we hack something together that's specific to a site? Or should we instead take the time to do things "right" by improving existing modules or writing our own new modules to contribute to the community? When is one of these options better than the other? How do we decide? It's a key set of questions. All but the most basic projects will require some level of new development. The way we approach this new development is probably _the most important factor_ in determining the long term value of our work, both for us and for our clients. It's a given that we'll first try to meet as much of the need as we can through existing, proven solutions. But there is always some need for customization. For smaller projects, new development might be:
 

--- a/practice-areas/engineering/security-compliance.md
+++ b/practice-areas/engineering/security-compliance.md
@@ -43,7 +43,7 @@ In particular:
     -   must use MFA for authentication/authorization
     -   are appropriately adjusted upon separation from CivicActions.
 
-### Advanced: Connecting to MFA-enabled Sevices/Apps
+### Advanced: Connecting to MFA-enabled Services/Apps
 
 Some applications and services may need to connect to your CivicActions Google account but they might not be able to handle Multi-Factor Authentication (MFA). An example of this would be a personal Gmail account trying to send e-mails through your civicactions' account. For this purpose Google has created something called [App Passwords](https://support.google.com/accounts/answer/185833?hl=en). [App Passwords](https://support.google.com/accounts/answer/185833?hl=en) allows you to create a unique password for each of your services/apps. If this password is used while authenticating your service/app to access your CivicActions' account it will bypass MFA.
 

--- a/practice-areas/engineering/security-compliance.md
+++ b/practice-areas/engineering/security-compliance.md
@@ -1,4 +1,6 @@
-# Security and Compliance
+---
+title: Security and Compliance
+---
 
 ## Security Policy
 

--- a/practice-areas/engineering/tech-lead.md
+++ b/practice-areas/engineering/tech-lead.md
@@ -1,4 +1,6 @@
-# Tech Lead (TL) Project Role Description
+---
+title: Tech Lead (TL) Project Role Description
+---
 
 CivicActions technical team leaders are known as "Tech Leads" (TL). The Tech Lead is responsible for the technical direction of the project. Tech Leads are involved in the entire project life cycle from estimating new business proposals and architecting solutions to leading development teams to work on the highest priorities and ensuring successful project completion. Our Tech Leads work in tandem with a project leadership team responsible for managing the project's overall progress and budget, which may include Design Lead, Project Managers, Scrum Masters, Engagement Managers, and/or Product Managers.
 

--- a/practice-areas/engineering/tech-lead.md
+++ b/practice-areas/engineering/tech-lead.md
@@ -186,6 +186,6 @@ Yes. Ultimately this project role (an individual or multiple team members) is gi
 -   [#engineering-techlead slack channel](https://civicactions.slack.com/archives/C017JL86MAM) (review the pinned messages).
 -   [Tech Lead Reading List](https://docs.google.com/spreadsheets/d/1QfK1-7IOqb7_N5451Y0FNiwvDlxirETVnl71sB_DUXE/edit#gid=0).
 -   [Tech Lead Call Agendas, Resources, and Notes](https://docs.google.com/document/d/1abRkMOuB9Kb2n8jlzjJnEClPCbAGOtZ6xclo6UlLiag/edit#heading=h.bsicsupyvxmj).
--   [Onboarding a New Project Team Member](../project-management/onboarding-new-project-team-member.md#onboarding-a-new-project-team-member).
+-   [Onboarding a New Project Team Member](../project-management/onboarding-new-project-team-member.md).
 
 <!--lint enable maximum-heading-length-->

--- a/practice-areas/help-desk/help-desk-agile.md
+++ b/practice-areas/help-desk/help-desk-agile.md
@@ -1,4 +1,6 @@
-# CivicActions Project Support and Agile
+---
+title: CivicActions Project Support and Agile
+---
 
 CivicActions project support practices follow Agile principles as follows:
 

--- a/practice-areas/help-desk/helpdesk.md
+++ b/practice-areas/help-desk/helpdesk.md
@@ -1,4 +1,6 @@
-# CivicActions Project Support
+---
+title: CivicActions Project Support
+---
 
 Note: this is the Project Support practice area. We have separate documentation that describes [how to request internal support](../../common-practices-tools/software-and-support/support.md).
 

--- a/practice-areas/help-desk/project-support-checklist.md
+++ b/practice-areas/help-desk/project-support-checklist.md
@@ -1,4 +1,6 @@
-# CivicActions Project Support Checklist
+---
+title: CivicActions Project Support Checklist
+---
 
 ## 1/ Start by defining "support" for your project team
 

--- a/practice-areas/help-desk/working-practices.md
+++ b/practice-areas/help-desk/working-practices.md
@@ -1,4 +1,6 @@
-# CivicActions Project Support Best Practices
+---
+title: CivicActions Project Support Best Practices
+---
 
 ## Overview
 

--- a/practice-areas/project-management/contract-expiration-tracking.md
+++ b/practice-areas/project-management/contract-expiration-tracking.md
@@ -1,4 +1,6 @@
-# Tracking Contract Details: Leveraging Project Wrappers
+---
+title: "Tracking Contract Details: Leveraging Project Wrappers"
+---
 
 ## Wrappers
 

--- a/practice-areas/project-management/contractual-requirements.md
+++ b/practice-areas/project-management/contractual-requirements.md
@@ -1,4 +1,6 @@
-# Tracking Contractual Requirements
+---
+title: Tracking Contractual Requirements
+---
 
 The project manager is the main team member responsible for ensuring the team stays on track for completing all the contractual and agreed upon deliverables. The PM should work closely with the tech lead and product owner to make sure contractual deliverables are being considered in sprint planning and completed by the agreed upon due dates. It is the PM's responsibility to be transparent with the PO and team if risks arise relating to the completion of contractual deliverables (to be tracked in a risk ledger).
 

--- a/practice-areas/project-management/general-tooling-guidelines-for-project-teams.md
+++ b/practice-areas/project-management/general-tooling-guidelines-for-project-teams.md
@@ -1,4 +1,6 @@
-# General Guidelines for Tools on Project Teams
+---
+title: General Guidelines for Tools on Project Teams
+---
 
 ## Slack
 

--- a/practice-areas/project-management/growth-mindset.md
+++ b/practice-areas/project-management/growth-mindset.md
@@ -1,4 +1,6 @@
-# Conflict Resolution and Growth Mindset
+---
+title: Conflict Resolution and Growth Mindset
+---
 
 ## Conflict Resolution
 

--- a/practice-areas/project-management/hard-conversations.md
+++ b/practice-areas/project-management/hard-conversations.md
@@ -1,4 +1,6 @@
-# Having the hard conversations
+---
+title: Having the hard conversations
+---
 
 As a Project Manager, there will be difficult conversations with clients such as budget overruns, deadline misses, launch failures and contract disagreements. What follows are some methods to minimize the negative impact of these discussions:
 

--- a/practice-areas/project-management/innovation.md
+++ b/practice-areas/project-management/innovation.md
@@ -1,4 +1,6 @@
-# Fostering innovation on project teams (MVP)
+---
+title: Fostering innovation on project teams (MVP)
+---
 
 Innovation is a key component to CivicActions work. We are committed to bringing innovation forward to our clients and - most especially - for end users. Innovation, therefore, is encouraged from all team members. The Project Manager is positioned to support the project team via the following (MVP version) process:
 

--- a/practice-areas/project-management/innovation.md
+++ b/practice-areas/project-management/innovation.md
@@ -21,7 +21,7 @@ Innovation is a key component to CivicActions work. We are committed to bringing
 
 -   Begin by leveraging existing team retros, working with ScrumMasters
 -   Create tickets in Jira (or another medium) for innovative ideas
--   Tickets should be tagged in a certain, yet consistent, manner (e.g., specific labels, componentes, issue type, etc.)
+-   Tickets should be tagged in a certain, yet consistent, manner (e.g., specific labels, components, issue type, etc.)
 -   Establish a custom, program-level board for tracking (or incorporate the innovation tickets into the existing backlog)
 -   Handoff ticket(s) to the Technical Lead (or another fitting role) for review during project leadership calls
 -   Request that the Technical Lead determine feasibility, LOE, ROI, etc., around the concept (and also noting feedback in the ticket, for transparency)

--- a/practice-areas/project-management/invoicing.md
+++ b/practice-areas/project-management/invoicing.md
@@ -1,4 +1,6 @@
-# Invoicing
+---
+title: Invoicing
+---
 
 When a project starts, the project manager should review invoicing requirements listed in the contract, and create a way to quickly reference this information each month. The most common info-noting methods project managers use is to create a separate document that outlines the invoicing requirements, along with all tasks they do during invoicing - this ensures another person can easily jump in to support invoicing in that project manager's absence.
 

--- a/practice-areas/project-management/leave-requests-and-stepping-away.md
+++ b/practice-areas/project-management/leave-requests-and-stepping-away.md
@@ -1,4 +1,6 @@
-# Leave Requests and Stepping Away: Guidelines for Project Managers
+---
+title: "Leave Requests and Stepping Away: Guidelines for Project Managers"
+---
 
 Guidelines that Project Managers may use to coach teams on communications for OOO and stepping away:
 

--- a/practice-areas/project-management/listserv-setup.md
+++ b/practice-areas/project-management/listserv-setup.md
@@ -1,4 +1,6 @@
-# Listserv Setup
+---
+title: Listserv Setup
+---
 
 We manage email lists via [Google Groups/Forum](https://groups.google.com/a/civicactions.net/forum/)
 

--- a/practice-areas/project-management/mods-and-extensions.md
+++ b/practice-areas/project-management/mods-and-extensions.md
@@ -1,4 +1,6 @@
-# When your project has a contractual Modification (Mod) or Extension
+---
+title: When your project has a contractual Modification (Mod) or Extension
+---
 
 ## What is the difference between a contract Mod and an Extension?
 

--- a/practice-areas/project-management/onboarding-new-project-team-member.md
+++ b/practice-areas/project-management/onboarding-new-project-team-member.md
@@ -1,4 +1,6 @@
-# Onboarding a New Project Team Member
+---
+title: Onboarding a New Project Team Member
+---
 
 Onboarding a new team member - to a project team - is a great opportunity for the Project Manager to confirm all project materials are in good standing. Some suggestions are as follows:
 

--- a/practice-areas/project-management/planning-onsite-meetings.md
+++ b/practice-areas/project-management/planning-onsite-meetings.md
@@ -1,4 +1,6 @@
-# Planning Travel/ Onsite Meetings
+---
+title: Planning Travel/ Onsite Meetings
+---
 
 We sometimes meet with clients "onsite" (or in their office) to conduct discovery research, and/or provide product demos. Any time travel is involved, use the [CivicActions Travel Details form template](https://docs.google.com/forms/d/19rqLkEh1xzjpri-vfN68xxmXvfcb5ThmmzJu1I6YYnM/edit) as a starting point for your planning. **Please make a copy of the template before completing it.** Do as much or as little planning as is appropriate for your specific project.
 

--- a/practice-areas/project-management/pm-role.md
+++ b/practice-areas/project-management/pm-role.md
@@ -1,4 +1,6 @@
-# The Project Manager Role
+---
+title: The Project Manager Role
+---
 
 Project Managers envelop the unique opportunity to hold a project on task and budget, which is paramount, yet also to include:
 

--- a/practice-areas/project-management/pm-training.md
+++ b/practice-areas/project-management/pm-training.md
@@ -1,4 +1,6 @@
-# Project Manager Training
+---
+title: Project Manager Training
+---
 
 Review [The Project Manager Role](pm-role.md) for an overview of PM responsibilities at CivicActions.
 

--- a/practice-areas/project-management/pm-unanet-tasks.md
+++ b/practice-areas/project-management/pm-unanet-tasks.md
@@ -145,7 +145,7 @@ Pro Tip: For finding OOO dates on the calendar, use the CivicActions shared cale
 1. Scroll down to Approvals
 1. Look for Expense Reports and/or Requests and click on Primary Approvals to view
 1. ![Screenshot of Approving Expense 1](../../assets/images/Approving-Expenses-1.png)
-1. NOTE: All expense reimbursements except for ProDev < \$50 should be submitted as a REQUEST first.
+1. NOTE: All expense reimbursements except for ProDev < $50 should be submitted as a REQUEST first.
 1. To check this quickly:
     1. Click on the magnifying glass next to the expense report
     1. Scroll down to Approval History

--- a/practice-areas/project-management/pm-unanet-tasks.md
+++ b/practice-areas/project-management/pm-unanet-tasks.md
@@ -1,4 +1,6 @@
-# Project Management: Unanet Tasks and Training Materials
+---
+title: "Project Management: Unanet Tasks and Training Materials"
+---
 
 ## Introduction
 
@@ -143,7 +145,7 @@ Pro Tip: For finding OOO dates on the calendar, use the CivicActions shared cale
 1. Scroll down to Approvals
 1. Look for Expense Reports and/or Requests and click on Primary Approvals to view
 1. ![Screenshot of Approving Expense 1](../../assets/images/Approving-Expenses-1.png)
-1. NOTE: All expense reimbursements except for ProDev < $50 should be submitted as a REQUEST first.
+1. NOTE: All expense reimbursements except for ProDev < \$50 should be submitted as a REQUEST first.
 1. To check this quickly:
     1. Click on the magnifying glass next to the expense report
     1. Scroll down to Approval History

--- a/practice-areas/project-management/project-calendar.md
+++ b/practice-areas/project-management/project-calendar.md
@@ -1,4 +1,6 @@
-# Calendars
+---
+title: Calendars
+---
 
 ## Project calendars
 

--- a/practice-areas/project-management/project-folder.md
+++ b/practice-areas/project-management/project-folder.md
@@ -1,4 +1,6 @@
-# Project Folder Structure
+---
+title: Project Folder Structure
+---
 
 Project Folders are integral to our transparency tenet at CivicActions. They also are necessary to retain a viable project record. An important part of the role of the Project Manager is the ongoing maintenance of project folders.
 

--- a/practice-areas/project-management/project-management-checklists.md
+++ b/practice-areas/project-management/project-management-checklists.md
@@ -1,4 +1,6 @@
-# Project Management checklists
+---
+title: Project Management checklists
+---
 
 The Project Management practice area suggests leveraging the following checklists for all projects:
 

--- a/practice-areas/project-management/project-offboarding.md
+++ b/practice-areas/project-management/project-offboarding.md
@@ -1,4 +1,6 @@
-# Offboarding A Team Member from a Project
+---
+title: Offboarding A Team Member from a Project
+---
 
 -   The project team is responsible for doing project specific offboarding. However, there is a company offboarding process where non-project specific offboarding is already tracked.
 -   The Project Manager should use a Trello card or Jira ticket (depending on the tool the project uses) to track offboarding tasks after the contractor's work is completed to ensure the contractor is properly removed from CivicActions tools, files, and the project. Consider preparing this ticket at the time of contractor onboarding so you have a place you can track all tools to which they are added over time.

--- a/practice-areas/project-management/starting-new-project.md
+++ b/practice-areas/project-management/starting-new-project.md
@@ -1,4 +1,6 @@
-# Guidelines for Starting a New Project
+---
+title: Guidelines for Starting a New Project
+---
 
 ## Pre-kickoff Checklist
 

--- a/practice-areas/project-management/team-working-agreements-instructions.md
+++ b/practice-areas/project-management/team-working-agreements-instructions.md
@@ -1,4 +1,6 @@
-# Team Working Agreements: Instructions for Project Managers
+---
+title: "Team Working Agreements: Instructions for Project Managers"
+---
 
 Note: See also Team Working Agreements (for all team members)
 

--- a/practice-areas/project-management/templates.md
+++ b/practice-areas/project-management/templates.md
@@ -121,7 +121,7 @@ To maintain the integrity of all Production systems, this template is an efficia
 
 ## Project brief (aka Onboarding deck)
 
-All projects intend to have an Onboarding deck for both CivicActions and partners, with the purpose of provide an overarching view of the projecs.
+All projects intend to have an Onboarding deck for both CivicActions and partners, with the purpose of provide an overarching view of the projects.
 
 [Project brief](https://docs.google.com/presentation/d/1Vk7DKxe5Sop6T3JhudOcLGCffH8XJXDiX8WtBbH3Te0/edit#slide=id.gd85224ffcd_0_0)
 

--- a/practice-areas/project-management/templates.md
+++ b/practice-areas/project-management/templates.md
@@ -1,4 +1,6 @@
-# Templates
+---
+title: Templates
+---
 
 ## Purpose
 


### PR DESCRIPTION
This adds https://decapcms.org/ - it is pointing at my fork of this repo for now, so we can play around with PRs etc without generating a bunch of noise.

Some notes:

- We need to use frontmatter "title" field rather than # style headers. As far as I can tell though, apart from the Github pages looking a bit naff everything else seems to work fine.
- The config can handle nested directory trees OK, but there are 2 issues:
    - The configuration requires a sub-directory for content, so I don't think we can just point it at the root directory (at least, I couldn't get it to work!) - so I was able to work around this by just listing each top-level directory separately, using some YAML aliases to avoid duplicating too much. So, we will need to remember to update this if we change any paths but other than that I think it is workable.
    - The file tree uses an README.md in each nested directory to identify the folder name - there might be another way of setting this up, but I think that would actually be nice for us to adopt anyway. This part isn't done, so expect the folder names to be wonky.
- I was able to inject some remark formatter configuration that makes it closer to our canonical format, but there will inevitably be some whitespace diffs in PRs generated by this - for example prettier wants a line after frontmatter and Decap doesn't (and I can't find a way to configure this). Not a major blocker, since these will be fixed by the auto pre-commit fixer.

<!-- readthedocs-preview civicactions-handbook start -->
----
:books: Documentation preview :books:: https://civicactions-handbook--1123.org.readthedocs.build/en/1123/

<!-- readthedocs-preview civicactions-handbook end -->