### PR TITLE
Fix broken link for http://status.aws.amazon.com/ since it has been failing continuously

### DIFF
--- a/common-practices-tools/security/contingency-plan.md
+++ b/common-practices-tools/security/contingency-plan.md
@@ -149,7 +149,7 @@ Primary incident communications will move to one of:
 ### AWS
 
 -   **Service:** <https://signin.aws.amazon.com/console>
--   **Status:** <http://status.aws.amazon.com/>
+-   **Status:** <https://health.aws.amazon.com/health/status>
 
 If needed, you can [manage and create new servers](https://console.aws.amazon.com/ec2/v2/home?region=us-east-1).
 
@@ -163,7 +163,7 @@ In case of a **significant** disruption, after receiving approval from our Autho
 Some sites are hosted on the Acquia Cloud Enterprise (ACE) PaaS
 <https://cloud.acquia.com/app/develop> which is layered on top of the Amazon Web Services
 (AWS) FedRAMP-certified cloud in the us-east region. See [ACE
-Status](https://status.acquia.com/) and [AWS status](http://status.aws.amazon.com/).
+Status](https://status.acquia.com/) and [AWS status](https://health.aws.amazon.com/health/status).
 
 -   **Acquia Security:** <https://docs.acquia.com/acquia-cloud/arch/security>
 -   **Acquia Monitoring:** <https://docs.acquia.com/acquia-cloud/arch/security/monitor>


### PR DESCRIPTION
See https://github.com/CivicActions/guidebook/actions/runs/4849959477/jobs/8642433937 and https://github.com/CivicActions/guidebook/actions/runs/4852163280/jobs/8646808647 for examples.

<!-- readthedocs-preview civicactions-handbook start -->
----
:books: Documentation preview :books:: https://civicactions-handbook--1124.org.readthedocs.build/en/1124/

<!-- readthedocs-preview civicactions-handbook end -->