### PR TITLE
Remove 'README' from a redirect

### DIFF
--- a/.config/redirects.yml
+++ b/.config/redirects.yml
@@ -479,5 +479,5 @@
   to_url: /practice-areas/design-and-research/content-modeling-guide/
   type: page
 - from_url: /about-civicactions/background-and-history/
-  to_url: /about-civicactions/README/
+  to_url: /about-civicactions/
   type: page

--- a/.config/update_rename_links.py
+++ b/.config/update_rename_links.py
@@ -208,8 +208,8 @@ def update_redirects(renames):
         redirects = yaml.safe_load(file)
 
     for old, new in renames:
-        old_url = "/" + old.removesuffix(".md") + "/"
-        new_url = "/" + new.removesuffix(".md") + "/"
+        old_url = "/" + old.removesuffix(".md").removesuffix("/README") + "/"
+        new_url = "/" + new.removesuffix(".md").removesuffix("/README") + "/"
 
         existing_redirect = None
         for redirect in redirects:


### PR DESCRIPTION
@grugnog https://guidebook.civicactions.com/en/latest/about-civicactions/background-and-history/ goes to https://guidebook.civicactions.com/en/latest/about-civicactions/README/ which is a 404 because of I materials theme or how readmes are treated with mkdocs. Probably need to update the magic mover but for now this is a small fix to the recent redirect.

<!-- readthedocs-preview civicactions-handbook start -->
----
:books: Documentation preview :books:: https://civicactions-handbook--1143.org.readthedocs.build/en/1143/

<!-- readthedocs-preview civicactions-handbook end -->