### PR TITLE
Update mkdocs.yml

### DIFF
--- a/.config/mkdocs.yml
+++ b/.config/mkdocs.yml
@@ -19,7 +19,7 @@ nav:
       - about-civicactions/annual-summit.md
   - Employee benefits:
       - employee-benefits/README.md
-      - Personal Time Off (PTO): employee-benefits/README.md
+      - Personal Time Off (US employees): employee-benefits/README.md
       - employee-benefits/us-compensation.md
       - employee-benefits/us-tech-stipend.md
       - employee-benefits/canada-benefits-policy.md


### PR DESCRIPTION
This PR amends the nav label to read "Personal Time Off (US employees) to be equivalent to Canadian page.

<!-- readthedocs-preview civicactions-handbook start -->
----
:books: Documentation preview :books:: https://civicactions-handbook--1229.org.readthedocs.build/en/1229/

<!-- readthedocs-preview civicactions-handbook end -->