### PR TITLE
Disable Decap workflow, since it confusingly duplicates Github workflow.

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -6,7 +6,6 @@ backend:
   branch: master
   base_url: https://v1.netlify-oauth.app.civicactions.net
   cms_label_prefix: decap/
-publish_mode: editorial_workflow
 media_folder: "assets/images"
 collections:
   # The &base defines this as a template element, reused with *base below to reduce duplication.


### PR DESCRIPTION


<!-- readthedocs-preview civicactions-handbook start -->
----
:books: Documentation preview :books:: https://civicactions-handbook--1253.org.readthedocs.build/en/1253/

<!-- readthedocs-preview civicactions-handbook end -->