### PR TITLE
Ignore linux.die.net in link checker

### DIFF
--- a/.config/markdown.links.config.json
+++ b/.config/markdown.links.config.json
@@ -60,6 +60,9 @@
     {
       "NOTE: Unreliable sites below": "",
       "pattern": "^https://nedjo.ca/.*"
+    },
+    {
+      "pattern": "^https://linux.die.net/.*"
     }
   ],
   "NOTE: We replace absolute links with a use-relative-links-to-md-files-only since these are (nearly) always mistakes and should link to the relative .md file instead": "",

--- a/.config/markdown.links.config.json
+++ b/.config/markdown.links.config.json
@@ -62,6 +62,9 @@
       "pattern": "^https://nedjo.ca/.*"
     },
     {
+      "pattern": "^http://linux.die.net/.*"
+    },
+    {
       "pattern": "^https://linux.die.net/.*"
     }
   ],


### PR DESCRIPTION
This should skip the links that keep failing (at least the https version).

<!-- readthedocs-preview civicactions-handbook start -->
----
:books: Documentation preview :books:: https://civicactions-handbook--1288.org.readthedocs.build/en/1288/

<!-- readthedocs-preview civicactions-handbook end -->