### PR TITLE
Updated link to default styles document

### DIFF
--- a/common-practices-tools/software-and-support/google-docs.md
+++ b/common-practices-tools/software-and-support/google-docs.md
@@ -8,7 +8,7 @@ title: Google Docs
 -   Google Docs should be shared with your CivicActions email account
 -   If a link is shared with you, you can add yourself to the share list so you can reference it later on
 -   If you are using a template, always make a COPY
--   Update [default paragraph styles](https://docs.google.com/document/d/1n1Jdu4vAnO0YCppo9YO2BkSYGyOqUCSJOrfrBBzBPBM/edit#) to match CivicActions standard styles when creating new docs to use/share
+-   Update [default paragraph styles](https://docs.google.com/document/d/1M-q4Wh0TfKctkaHRmJQumsIn_faTimyTub8qu3qGM7k/edit) to match CivicActions standard styles when creating new docs to use/share
 -   When you create a document, set permissions so "anyone at CivicActions can find and access"
 -   Make sure to place documents & files in appropriate project folder instead of it living at your personal My Drive
 


### PR DESCRIPTION
Link was previously going to an older version.

<!-- readthedocs-preview civicactions-handbook start -->
----
:books: Documentation preview :books:: https://civicactions-handbook--1290.org.readthedocs.build/en/1290/

<!-- readthedocs-preview civicactions-handbook end -->