### PR TITLE
Remove incorrect reference

### DIFF
--- a/about-this-guidebook/markdown-for-guidebook.md
+++ b/about-this-guidebook/markdown-for-guidebook.md
@@ -20,7 +20,7 @@ There's a great tutorial [on the Commonmark website](http://commonmark.org/help/
 
 ## Format auto-correct
 
--   Many common Markdown formatting issues will be automatically corrected after you submit your Pull Request by the FOSS [Restyler](https://restyled.io/).
+-   Many common Markdown formatting issues will be automatically corrected after you submit your Pull Request.
 -   This applies the FOSS tool [Prettier](https://prettier.io/) using the default configuration, which is our canonical standard.
 
 ## Markdown checking (linter)


### PR DESCRIPTION
We now use pre-commit, but I don't think that is a relevant detail for editors

<!-- readthedocs-preview civicactions-handbook start -->
----
:books: Documentation preview :books:: https://civicactions-handbook--1305.org.readthedocs.build/en/1305/

<!-- readthedocs-preview civicactions-handbook end -->