### PR TITLE
Replacing knowledge center link with support link

### DIFF
--- a/company-policies/timesheets.md
+++ b/company-policies/timesheets.md
@@ -117,7 +117,7 @@ To get help with timesheets, project codes, and using Unanet:
 
 -   Join #unanet in Slack and ping @unanet_support
 -   View pinned items in the #unanet slack channel
--   Search the [Unanet Knowledge Center](https://knowledgecenter.unanet.com/display/kb/End+User+Training)
+-   Search the [Unanet knowledge center from the support center (requires account)](https://support.unanet.com/)
 -   [Instructions](https://docs.google.com/presentation/d/1IEl3c8pOAYz5KNM4tVDemjvx5O-5m5WF21r4saANsFw/edit#slide=id.gce3d6a447a_0_89) (deck)
 -   [Time Off policy (US)](../employee-benefits/README.md)
 -   [Time Off policy (Canada)](../employee-benefits/canada-benefits-policy.md)


### PR DESCRIPTION
Discussed in slack and we want to keep the link.

<!-- readthedocs-preview civicactions-handbook start -->
----
:books: Documentation preview :books:: https://civicactions-handbook--1306.org.readthedocs.build/en/1306/

<!-- readthedocs-preview civicactions-handbook end -->