### PR TITLE
Adding CSS overrides to improve color contrast of copyright and github details

### DIFF
--- a/assets/css/extra.css
+++ b/assets/css/extra.css
@@ -26,6 +26,12 @@ a.md-tabs__link.md-tabs__link--active {
 .md-content__inner a {
   text-decoration: underline;
 }
+.md-copyright {
+  color: #ffffff;
+}
+.md-source__facts {
+  opacity: 1;
+}
 /* The Read the Docs flyout is formatted with a font-size that is 90% of the
 body's. Material for MkDocs has a body font-size that is 0.5rem. This font-size
 will result in the flyout having a font-size of 0.7rem, consistent with the


### PR DESCRIPTION
Relates to #1307 

<!-- readthedocs-preview civicactions-handbook start -->
----
:books: Documentation preview :books:: https://civicactions-handbook--1308.org.readthedocs.build/en/1308/

<!-- readthedocs-preview civicactions-handbook end -->