### PR TITLE
Fixing security links

### DIFF
--- a/common-practices-tools/security/README.md
+++ b/common-practices-tools/security/README.md
@@ -118,7 +118,7 @@ Social engineering is the most common attack vector used to compromise computer 
     -   As usual, never enter your name or password information:
         -   when on an insecure (non-HTTPS or SSL encrypted) connection, or
         -   to a site that you have not verified is correct (by examining at the URL)
-    -   [More on public Wi-Fi network safety (from LifeHacker)](http://lifehacker.com/5576927/how-to-stay-safe-on-public-wi-fi-networks)
+    -   [More on public Wi-Fi network safety (from FTC)](https://consumer.ftc.gov/articles/are-public-wi-fi-networks-safe-what-you-need-know)
 
 ## Keep your systems up-to-date
 

--- a/company-policies/new-hire-orientation/security-training.md
+++ b/company-policies/new-hire-orientation/security-training.md
@@ -11,7 +11,7 @@ As a requirement for employment, every employee must review and acknowledge the 
 -   [Acceptable Use Policy](../security.md#acceptable-use-policy)
 -   [Access Policy](../security.md#access-policy)
 -   [Password Policy](../security.md#password-policy)
--   [Server & Site Security](../security.md#server-and-site-security)
+-   [Server & Site Security](../../practice-areas/engineering/security-compliance.md#server-and-site-security)
 
 <!-- TODO: include link to digital document signing -->
 


### PR DESCRIPTION
Updating the links in security training and the one in practices & tools.

<!-- readthedocs-preview civicactions-handbook start -->
----
:books: Documentation preview :books:: https://civicactions-handbook--1315.org.readthedocs.build/en/1315/

<!-- readthedocs-preview civicactions-handbook end -->