### PR TITLE
Fixing 404 link in sprint-planning-meetings.md

### DIFF
--- a/.config/remark/remarkrc.problem
+++ b/.config/remark/remarkrc.problem
@@ -1,6 +1,6 @@
 {
   "settings": {
-    "listItemIndent": "1",
+    "listItemIndent": "tab",
     "bullet": "-",
     "strong": "*",
     "emphasis": "_",

--- a/common-practices-tools/agile/sprint-planning-meetings.md
+++ b/common-practices-tools/agile/sprint-planning-meetings.md
@@ -44,4 +44,4 @@ The Sprint Planning Meeting is arguably the most important meeting of a sprint c
 ## Additional Resources
 
 -   [Scrum Training Series Video](http://scrumtrainingseries.com/SprintPlanningMeeting/SprintPlanningMeeting.htm)
--   [A Sprint Planning Cheat Sheet](http://www.leadingagile.com/2012/08/simple-cheat-sheet-to-sprint-planning-meeting/)
+-   [A Sprint Planning Cheat Sheet](https://www.leadingagile.com/simple-cheat-sheet-to-sprint-planning-meeting/)

--- a/common-practices-tools/agile/sprint-planning-meetings.md
+++ b/common-practices-tools/agile/sprint-planning-meetings.md
@@ -22,7 +22,7 @@ Once the product backlog has been prioritized by the Product Owner and those sto
 
 A Sprint Planning Meeting usually includes the following:
 
-1.  The Product Owner provides a brief review of the "big picture" or main project goal, then shares his/her highest prioritized stories. The PO should present enough stories for about 2 full sprints worth of work.
+1.  The Product Owner provides a brief review of the "big picture" or main project goal, then shares their highest prioritized stories. The PO should present enough stories for about 2 full sprints worth of work.
 2.  Discuss and confirm the team's potential capacity and velocity for the sprint. This may include discussions about scheduled time off for any team members, holidays, velocity in previous sprints, and anything else that could influence capacity or velocity.
 3.  With the most important backlog items having been stated and project capacities having been defined, the project team and Product Owner use this information to develop a "Sprint Goal". This is a one to two sentence statement that describes what the team plans to accomplish during the sprint.
 4.  The team examines and discusses the highest priority items in the product backlog as defined by the Product Owner. The project team may ask questions of the Product Owner to clarify stories and tasks.


### PR DESCRIPTION
Old page: http://www.leadingagile.com/2012/08/simple-cheat-sheet-to-sprint-planning-meeting/, new page: https://www.leadingagile.com/simple-cheat-sheet-to-sprint-planning-meeting/.

<!-- readthedocs-preview civicactions-handbook start -->
----
📚 Documentation preview 📚: https://civicactions-handbook--1338.org.readthedocs.build/en/1338/

<!-- readthedocs-preview civicactions-handbook end -->