### PR TITLE
Ignore https://hemingwayapp.com/ in link checker

### DIFF
--- a/.config/markdown.links.config.json
+++ b/.config/markdown.links.config.json
@@ -66,6 +66,9 @@
     },
     {
       "pattern": "^https://linux.die.net/.*"
+    },
+    {
+      "pattern": "^https://hemingwayapp.com/.*"
     }
   ],
   "NOTE: We replace absolute links with a use-relative-links-to-md-files-only since these are (nearly) always mistakes and should link to the relative .md file instead": "",


### PR DESCRIPTION
Recently it has been throwing up 500 errors whenever link checker runs, e.g. https://github.com/CivicActions/guidebook/actions/runs/7746954819/job/21126345908?pr=1345

<!-- readthedocs-preview civicactions-handbook start -->
----
📚 Documentation preview 📚: https://civicactions-handbook--1346.org.readthedocs.build/en/1346/

<!-- readthedocs-preview civicactions-handbook end -->