### PR TITLE
Ignoring duckduckgo from link checker

### DIFF
--- a/.config/markdown.links.config.json
+++ b/.config/markdown.links.config.json
@@ -66,6 +66,9 @@
     },
     {
       "pattern": "^https://linux.die.net/.*"
+    },
+    {
+      "pattern": "^https://duckduckgo.com/.*"
     }
   ],
   "NOTE: We replace absolute links with a use-relative-links-to-md-files-only since these are (nearly) always mistakes and should link to the relative .md file instead": "",


### PR DESCRIPTION
Seems that the https://duckduckgo.com/ links in https://guidebook.civicactions.com/en/latest/common-practices-tools/security/encryption/#private-browsing keeps failing with 403 access denied, e.g. https://github.com/CivicActions/guidebook/actions/runs/7893190328/job/21541283471?pr=1350

<!-- readthedocs-preview civicactions-handbook start -->
----
📚 Documentation preview 📚: https://civicactions-handbook--1351.org.readthedocs.build/en/1351/

<!-- readthedocs-preview civicactions-handbook end -->