### PR TITLE
Updating link in security

### DIFF
--- a/.config/markdown.links.config.json
+++ b/.config/markdown.links.config.json
@@ -69,6 +69,9 @@
     },
     {
       "pattern": "^https://duckduckgo.com/.*"
+    },
+    {
+      "pattern": "^https://askubuntu.com/.*"
     }
   ],
   "NOTE: We replace absolute links with a use-relative-links-to-md-files-only since these are (nearly) always mistakes and should link to the relative .md file instead": "",

--- a/common-practices-tools/security/README.md
+++ b/common-practices-tools/security/README.md
@@ -171,7 +171,7 @@ When you delete a file, it doesn't actually go away. Usually, all that occurs is
 
 GNU/Linux:
 
--   [How to delete file(s) in secure manner?](http://askubuntu.com/questions/57572/how-to-delete-files-in-secure-manner) (Ask Ubuntu)
+-   [How to delete file(s) in secure manner?](https://askubuntu.com/questions/57572/how-to-delete-files-in-secure-manner) (Ask Ubuntu)
 -   [How to: Delete your Data Securely on Linux](https://ssd.eff.org/en/module/how-delete-your-data-securely-linux) (from the EFF Surveillance Self-Defense guide)
 
 MacOS:


### PR DESCRIPTION
Testing whether switching from http to https fixes the link checker 403 error from https://github.com/CivicActions/guidebook/actions/runs/7957009004/job/21718872375. That didn't work so ignoring `askubuntu.com` from the link checker.

<!-- readthedocs-preview civicactions-handbook start -->
----
📚 Documentation preview 📚: https://civicactions-handbook--1356.org.readthedocs.build/en/1356/

<!-- readthedocs-preview civicactions-handbook end -->