### PR TITLE
Need to set VIRTUALENV for readthedocs to install mkdocs dependencies.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,11 +19,12 @@ build:
       # Configure git authentication
       - git config --global credential.helper store
       - echo "https://${GH_TOKEN}:@github.com" > $HOME/.git-credentials
+      # Install packages
       # VIRTUAL_ENV needs to be set manually for now.
       # See https://github.com/readthedocs/readthedocs.org/pull/11152/
       - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry -C .config/mkdocs/ install
     pre_build:
-      # Symlink all files to a .docs directory so we can build outside the root
+      # Symlink all files to a .docs directory, so we can build outside the root
       - ln -sfT . .docs
 
 mkdocs:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,14 +15,13 @@ build:
       # Install poetry
       # https://python-poetry.org/docs/#installing-manually
       - pip install poetry
-      # Tell poetry to not use a virtual environment
-      - poetry config virtualenvs.create false
     post_install:
       # Configure git authentication
       - git config --global credential.helper store
       - echo "https://${GH_TOKEN}:@github.com" > $HOME/.git-credentials
-      # Install packages
-      - poetry -C .config/mkdocs/ install
+      # VIRTUAL_ENV needs to be set manually for now.
+      # See https://github.com/readthedocs/readthedocs.org/pull/11152/
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry -C .config/mkdocs/ install
     pre_build:
       # Symlink all files to a .docs directory so we can build outside the root
       - ln -sfT . .docs


### PR DESCRIPTION
As pointed out in https://github.com/readthedocs/readthedocs.org/issues/11176, this configuration is needed for Read the docs to install our dependencies and build the site.

<!-- readthedocs-preview civicactions-handbook start -->
----
📚 Documentation preview 📚: https://civicactions-handbook--1360.org.readthedocs.build/en/1360/

<!-- readthedocs-preview civicactions-handbook end -->