### PR TITLE
Setting the errorformat matching manually for reviewdog.

### DIFF
--- a/.config/remark/remark.sh
+++ b/.config/remark/remark.sh
@@ -17,6 +17,11 @@ export REMARK_PATHS=$(git diff --diff-filter=AM --name-only "${MASTER}" ':*.md')
 
 if [[ -n "${INPUT_GITHUB_TOKEN:-}" ]]; then
   export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
+
+  # For reviewdog we removed '-f=remark-lint' option because the remark output format changed. A fix has been submitted
+  # at https://github.com/reviewdog/errorformat/pull/146. Once the fix is merged and deployed to a new version of
+  # reviewdog we can put the option back and remove -efm options.
+
   remark --rc-path=/usr/src/remarkrc.suggestion --no-color ${REMARK_PATHS} 2>&1 >/dev/null |
     reviewdog -efm="%-P%f" \
       -efm="%#%l:%c %# %trror %m" \

--- a/.config/remark/remark.sh
+++ b/.config/remark/remark.sh
@@ -18,7 +18,11 @@ export REMARK_PATHS=$(git diff --diff-filter=AM --name-only "${MASTER}" ':*.md')
 if [[ -n "${INPUT_GITHUB_TOKEN:-}" ]]; then
   export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
   remark --rc-path=/usr/src/remarkrc.suggestion --no-color ${REMARK_PATHS} 2>&1 >/dev/null |
-    reviewdog -f=remark-lint \
+    reviewdog -efm="%-P%f" \
+      -efm="%#%l:%c %# %trror %m" \
+      -efm="%#%l:%c %# %tarning %m" \
+      -efm="%-Q" \
+      -efm="%-G%.%#" \
       -name="remark-lint-suggestions" \
       -reporter="github-pr-check" \
       -fail-on-error="false" \
@@ -26,7 +30,11 @@ if [[ -n "${INPUT_GITHUB_TOKEN:-}" ]]; then
       -tee
 
   remark --rc-path=/usr/src/remarkrc.problem --no-color ${REMARK_PATHS} 2>&1 >/dev/null |
-    reviewdog -f=remark-lint \
+    reviewdog -efm="%-P%f" \
+      -efm="%#%l:%c %# %trror %m" \
+      -efm="%#%l:%c %# %tarning %m" \
+      -efm="%-Q" \
+      -efm="%-G%.%#" \
       -name="remark-lint-problem" \
       -reporter="github-pr-check" \
       -fail-on-error="true" \


### PR DESCRIPTION
Haven't seen any traction with fixing the remark-lint errorformat here https://github.com/reviewdog/errorformat/pull/146 so for now hardcoding the format for our reviewdog commands.

Tested it in #1099 and you can see it is working again https://github.com/CivicActions/guidebook/pull/1099/files. I cherry-picked the commit over.

<!-- readthedocs-preview civicactions-handbook start -->
----
📚 Documentation preview 📚: https://civicactions-handbook--1363.org.readthedocs.build/en/1363/

<!-- readthedocs-preview civicactions-handbook end -->