### PR TITLE
Reviewdog update

### DIFF
--- a/.config/remark/Dockerfile
+++ b/.config/remark/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM node:18-alpine
 
-ENV REVIEWDOG_VERSION=v0.13.1
+ENV REVIEWDOG_VERSION=v0.18.1
 
 RUN \
   apk add --update \

--- a/.config/remark/package.json
+++ b/.config/remark/package.json
@@ -13,7 +13,7 @@
     "remark-lint-code-block-style": "^3.1.2",
     "remark-lint-definition-case": "^3.1.2",
     "remark-lint-definition-spacing": "^4.0.0",
-    "remark-lint-emphasis-marker": "^3.1.2",
+    "remark-lint-emphasis-marker": "^4.0.0",
     "remark-lint-fenced-code-flag": "^4.0.0",
     "remark-lint-fenced-code-marker": "^3.1.2",
     "remark-lint-file-extension": "^2.1.2",

--- a/.config/remark/remark.sh
+++ b/.config/remark/remark.sh
@@ -23,11 +23,7 @@ if [[ -n "${INPUT_GITHUB_TOKEN:-}" ]]; then
   # reviewdog we can put the option back and remove -efm options.
 
   remark --rc-path=/usr/src/remarkrc.suggestion --no-color ${REMARK_PATHS} 2>&1 >/dev/null |
-    reviewdog -efm="%-P%f" \
-      -efm="%#%l:%c %# %trror %m" \
-      -efm="%#%l:%c %# %tarning %m" \
-      -efm="%-Q" \
-      -efm="%-G%.%#" \
+    reviewdog -f=remark-lint \
       -name="remark-lint-suggestions" \
       -reporter="github-pr-check" \
       -fail-on-error="false" \
@@ -35,11 +31,7 @@ if [[ -n "${INPUT_GITHUB_TOKEN:-}" ]]; then
       -tee
 
   remark --rc-path=/usr/src/remarkrc.problem --no-color ${REMARK_PATHS} 2>&1 >/dev/null |
-    reviewdog -efm="%-P%f" \
-      -efm="%#%l:%c %# %trror %m" \
-      -efm="%#%l:%c %# %tarning %m" \
-      -efm="%-Q" \
-      -efm="%-G%.%#" \
+    reviewdog -f=remark-lint \
       -name="remark-lint-problem" \
       -reporter="github-pr-check" \
       -fail-on-error="true" \

--- a/.config/remark/remark.sh
+++ b/.config/remark/remark.sh
@@ -17,11 +17,6 @@ export REMARK_PATHS=$(git diff --diff-filter=AM --name-only "${MASTER}" ':*.md')
 
 if [[ -n "${INPUT_GITHUB_TOKEN:-}" ]]; then
   export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
-
-  # For reviewdog we removed '-f=remark-lint' option because the remark output format changed. A fix has been submitted
-  # at https://github.com/reviewdog/errorformat/pull/146. Once the fix is merged and deployed to a new version of
-  # reviewdog we can put the option back and remove -efm options.
-
   remark --rc-path=/usr/src/remarkrc.suggestion --no-color ${REMARK_PATHS} 2>&1 >/dev/null |
     reviewdog -f=remark-lint \
       -name="remark-lint-suggestions" \

--- a/.config/remark/yarn.lock
+++ b/.config/remark/yarn.lock
@@ -2192,17 +2192,6 @@ remark-lint-definition-spacing@^4.0.0:
     unified-lint-rule "^3.0.0"
     unist-util-visit-parents "^6.0.0"
 
-remark-lint-emphasis-marker@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/remark-lint-emphasis-marker/-/remark-lint-emphasis-marker-3.1.2.tgz#f86034ce0641fcf38590a4cd83e310d491be6390"
-  integrity sha512-hPZ8vxZrIfxmLA5B66bA8y3PdHjcCQuaLsySIqi5PM2DkpN6a7zAP3v1znyRSaYJ1ANVWcu00/0bNzuUjflGCA==
-  dependencies:
-    "@types/mdast" "^3.0.0"
-    unified "^10.0.0"
-    unified-lint-rule "^2.0.0"
-    unist-util-position "^4.0.0"
-    unist-util-visit "^4.0.0"
-
 remark-lint-emphasis-marker@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/remark-lint-emphasis-marker/-/remark-lint-emphasis-marker-4.0.0.tgz#9d2f6515116479641ec6e602e3c8e7276a81c165"
@@ -3624,16 +3613,7 @@ sprintf-js@^1.1.3:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.3.tgz#4914b903a2f8b685d17fdf78a70e917e872e444a"
   integrity sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -3675,14 +3655,7 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
Reverting #1363 after update of reviewdog to fix this issue https://github.com/reviewdog/errorformat/issues/145 

The successful reports can be seen in these URLs (I was testing with the content from #1099)
- https://github.com/CivicActions/guidebook/pull/1394/checks?check_run_id=26825851346
- https://github.com/CivicActions/guidebook/pull/1394/checks?check_run_id=26825852384
- https://github.com/CivicActions/guidebook/actions/runs/9718292824/job/26825836358?pr=1394

<!-- readthedocs-preview civicactions-handbook start -->
----
📚 Documentation preview 📚: https://civicactions-handbook--1394.org.readthedocs.build/en/1394/

<!-- readthedocs-preview civicactions-handbook end -->