### PR TITLE
Created a bash script to lookup the material insiders latest version

### DIFF
--- a/.github/workflows/material-insiders-update.yml
+++ b/.github/workflows/material-insiders-update.yml
@@ -1,0 +1,33 @@
+name: Checking material insiders update
+
+on:
+  # Automatic check monthly
+  schedule:
+    - cron: "0 10 1 * *"
+  # Manually triggered using GitHub's UI
+  workflow_dispatch:
+
+jobs:
+  mkdocs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - uses: snok/install-poetry@v1
+        with:
+          version: 1.3.2
+      - name: Run material insiders script to check version.
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: ./.config/mkdocs/check-material-insiders-version.sh
+      - name: Create pull request if there is a new version
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: Update material insiders version to latest version
+          title: Update material insiders version to latest version
+          body: Verify the new version works and there are no side effects (theme color reverting). Confirm all checks are passing.
+          branch: update-material-insiders


### PR DESCRIPTION
Added a github action to do that automatically with a pull request.

Fixes #1094 

To run it locally:

- Checkout branch `materials-insider-auto-update`
- Run script `./.config/mkdocs/check-material-insiders-version.sh` (if needed make sure it has user executable permission).
- Confirm it installs a newer version of mkdocs-material theme. 

<!-- readthedocs-preview civicactions-handbook start -->
----
📚 Documentation preview 📚: https://civicactions-handbook--1405.org.readthedocs.build/en/1405/

<!-- readthedocs-preview civicactions-handbook end -->