### PR TITLE
Creating md links in drupal-for-drupal-engineers.md

### DIFF
--- a/.config/linkspector.yml
+++ b/.config/linkspector.yml
@@ -1,3 +1,6 @@
 dirs:
   - .
 useGitIgnore: true
+ignorePatterns:
+  # NOTE: Sites with captcha protection below
+  - pattern: "^https://.*drupal.org/.*"

--- a/.config/remark/package.json
+++ b/.config/remark/package.json
@@ -57,7 +57,7 @@
     "remark-lint-no-undefined-references": "^5.0.0",
     "remark-lint-no-unused-definitions": "^3.1.2",
     "remark-lint-ordered-list-marker-style": "^3.1.2",
-    "remark-lint-ordered-list-marker-value": "^3.1.2",
+    "remark-lint-ordered-list-marker-value": "^4.0.0",
     "remark-lint-rule-style": "^3.1.2",
     "remark-lint-strong-marker": "^4.0.0",
     "remark-lint-table-cell-padding": "^5.0.0",

--- a/.config/remark/yarn.lock
+++ b/.config/remark/yarn.lock
@@ -2979,18 +2979,6 @@ remark-lint-ordered-list-marker-style@^4.0.0:
     unist-util-visit-parents "^6.0.0"
     vfile-message "^4.0.0"
 
-remark-lint-ordered-list-marker-value@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/remark-lint-ordered-list-marker-value/-/remark-lint-ordered-list-marker-value-3.1.2.tgz#a2bb783c184a76b73eee2560916fa2bd43494239"
-  integrity sha512-kG08nhsFk8rhoXK5EeDN/wN28CxefraDud/MaZnji8LEyxF3HAkzFuETr9laOn8Ey+n8h/C0mpqAwUf4thyJ5g==
-  dependencies:
-    "@types/mdast" "^3.0.0"
-    unified "^10.0.0"
-    unified-lint-rule "^2.0.0"
-    unist-util-generated "^2.0.0"
-    unist-util-position "^4.0.0"
-    unist-util-visit "^4.0.0"
-
 remark-lint-ordered-list-marker-value@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/remark-lint-ordered-list-marker-value/-/remark-lint-ordered-list-marker-value-4.0.0.tgz#a0724a161b2dbcd6dd0be6088e851b3183baab0e"
@@ -3568,16 +3556,7 @@ sprintf-js@^1.1.3:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.3.tgz#4914b903a2f8b685d17fdf78a70e917e872e444a"
   integrity sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -3619,14 +3598,7 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==

--- a/practice-areas/engineering/drupal/drupal-for-drupal-engineers.md
+++ b/practice-areas/engineering/drupal/drupal-for-drupal-engineers.md
@@ -20,8 +20,8 @@ If you need to create your own patch, attach it to the issue and update it accor
 
 Your project's technical lead can show you where patch files are stored in your project and explain how they are applied.
 
-[https://www.drupal.org/community/contributor-guide/reference-information/quick-info/life-cycle-of-an-issue](https://www.drupal.org/community/contributor-guide/reference-information/quick-info/life-cycle-of-an-issue)
-[https://www.drupal.org/docs/develop/using-composer/using-composer-with-drupal](https://www.drupal.org/docs/develop/using-composer/using-composer-with-drupal)
+- [https://www.drupal.org/community/contributor-guide/reference-information/quick-info/life-cycle-of-an-issue](https://www.drupal.org/community/contributor-guide/reference-information/quick-info/life-cycle-of-an-issue)
+- [https://www.drupal.org/docs/develop/using-composer/using-composer-with-drupal](https://www.drupal.org/docs/develop/using-composer/using-composer-with-drupal)
 
 ## Version control and the code review process
 

--- a/practice-areas/engineering/drupal/drupal-for-drupal-engineers.md
+++ b/practice-areas/engineering/drupal/drupal-for-drupal-engineers.md
@@ -6,7 +6,7 @@ title: Drupal for Drupal engineers
 
 ## Follow coding standards
 
-We strictly follow established coding standards. Standardized code is more readable and easier to maintain. See the Drupal docs for the latest guidelines: https://www.drupal.org/docs/develop/standards
+We strictly follow established coding standards. Standardized code is more readable and easier to maintain. See the [Drupal docs for the latest guidelines](https://www.drupal.org/docs/develop/standards).
 
 ## Contributing upstream
 
@@ -20,8 +20,8 @@ If you need to create your own patch, attach it to the issue and update it accor
 
 Your project's technical lead can show you where patch files are stored in your project and explain how they are applied.
 
-https://www.drupal.org/community/contributor-guide/reference-information/quick-info/life-cycle-of-an-issue
-https://www.drupal.org/docs/develop/using-composer/using-composer-with-drupal
+[https://www.drupal.org/community/contributor-guide/reference-information/quick-info/life-cycle-of-an-issue](https://www.drupal.org/community/contributor-guide/reference-information/quick-info/life-cycle-of-an-issue)
+[https://www.drupal.org/docs/develop/using-composer/using-composer-with-drupal](https://www.drupal.org/docs/develop/using-composer/using-composer-with-drupal)
 
 ## Version control and the code review process
 
@@ -52,16 +52,16 @@ The monthly meeting itself is normally scheduled early in the month and follows 
 
 These formats are not set in stone, though; feel free to suggest another format entirely. Even better: volunteer to lead the next call and try something new out!
 
-More recently, we've been adding agenda items and notes to this document: 2022 Drupal Practice Area Meetings and Agendas to structure our conversations.
+More recently, we've been adding agenda items and notes to this document: [2022 Drupal Practice Area Meetings and Agendas](https://docs.google.com/document/d/129pvtjRwknQcMcsgwMfAHKGViXpQC6cElw-AIqzussU/edit?tab=t.0#heading=h.tnwg29sodagt) to structure our conversations.
 
 ### Drupal practice area OKRs
 
-CivicActions adopted a standard practice of setting Objectives and Key Results in 2020, based on learnings gleaned from this book: https://www.amazon.com/Measure-What-Matters-Simple-Drives/dp/024134848X/ref=sr_1_1
+CivicActions adopted a standard practice of setting Objectives and Key Results in 2020, based on learnings gleaned from this book: [https://www.amazon.com/Measure-What-Matters-Simple-Drives/dp/024134848X/ref=sr_1_1](https://www.amazon.com/Measure-What-Matters-Simple-Drives/dp/024134848X/ref=sr_1_1)
 
 We are still in the process of optimizing our practices in this area. Drupal practice area OKRs have been developed that align with CivicActions organizational objectives. OKR discussions happen frequently in practice area calls and
 
--   Trello board: https://trello.com/b/MH1OIHzV/drupal-practice-area-okrs
--   Culture amp: https://civicactions.cultureamp.com/performance/new_goals/department
+-   Trello board (read-only): [https://trello.com/b/MH1OIHzV/drupal-practice-area-okrs](https://trello.com/b/MH1OIHzV/drupal-practice-area-okrs)
+-   Culture amp: [https://civicactions.cultureamp.com/performance/new_goals/department](https://civicactions.cultureamp.com/performance/new_goals/department)
 
 ### Skillsbase: Complete a self-assessment of your Drupal skills
 
@@ -86,10 +86,10 @@ We encourage all CivicActioners to give back to the Drupal community (see commun
 
 Update your drupal.org profile
 
-1. Go to https://drupal.org/.
+1. Go to [https://drupal.org/](https://drupal.org/).
 2. Log into your drupal.org account (create one if you do not have one).
 3. Align it with CivicActions in the "Work" section: Edit profile > Then expand the Work section > Type in "CivicActions" and your Job title.
-4. Align your role with CivicActions in the "Contributor roles" section: Edit profile > Then expand the Contributor roles section > Type in "CivicActions" in "Organization support". See https://www.drupal.org/community/contributor-guide/find-your-role for more details.
+4. Align your role with CivicActions in the "Contributor roles" section: Edit profile > Then expand the Contributor roles section > Type in "CivicActions" in "Organization support". See [https://www.drupal.org/community/contributor-guide/find-your-role](https://www.drupal.org/community/contributor-guide/find-your-role) for more details.
 
 ### Contribution to drupal.org modules and themes
 
@@ -97,7 +97,7 @@ If you have created or are creating a module or a theme and use CivicActions tim
 
 ![supporting organizations](../../../assets/images/drupal-pa-support-org-screenshot.png)
 
-Adding the organization will ensure that the module and theme will also be attributed to CivicActions. Examples of that can be seen under https://www.drupal.org/civicactions#projects-supported.
+Adding the organization will ensure that the module and theme will also be attributed to CivicActions. Examples of that can be seen under [https://www.drupal.org/civicactions#projects-supported](https://www.drupal.org/civicactions#projects-supported).
 
 ### Contributing to drupal.org issues
 
@@ -105,7 +105,7 @@ If you are contributing to drupal.org issues for CivicActions and our customers,
 
 ![attribute organization](../../../assets/images/drupal-pa-contribution-attribution-screenshot.png)
 
-Checking the box and adding the organization and customer will ensure that any credit you receive will also be attributed to CivicActions and the customer. Examples of that can be seen under https://www.drupal.org/civicactions#org-page-issue-credit.
+Checking the box and adding the organization and customer will ensure that any credit you receive will also be attributed to CivicActions and the customer. Examples of that can be seen under [https://www.drupal.org/civicactions#org-page-issue-credit](https://www.drupal.org/civicactions#org-page-issue-credit).
 
 ### External Resources
 

--- a/practice-areas/engineering/drupal/drupal-for-drupal-engineers.md
+++ b/practice-areas/engineering/drupal/drupal-for-drupal-engineers.md
@@ -10,15 +10,15 @@ We strictly follow established coding standards. Standardized code is more reada
 
 ## Contributing upstream
 
-Whenever practical, we want to contribute our changes back to the Drupal community. If a change requires us to patch core or a contributed module, that patch should also be attached to a drupal.org issue.
+Whenever practical, we want to contribute our changes back to the Drupal community. If a change requires us to patch core or a contributed module, that patch should also be attached to a drupal.org issue or the changes submitted via a merge request.
 
-First, search the Drupal project for an issue matching the change you need to make. There may already be a patch providing the functionality.
+First, search the Drupal project for an issue matching the change you need to make. There may already be a fix providing the functionality.
 
-If you end up using an existing patch, drop a comment indicating that you tested the patch and that it is working (or not) for you. This will help move the issue along its lifecycle.
+If you end up using an existing fix, drop a comment indicating that you tested it and that it is working (or not) for you. This will help move the issue along its lifecycle.
 
-If you need to create your own patch, attach it to the issue and update it accordingly. Ensure that the patch file is named according to convention and includes the issue number so that it is convenient to find.
+If you need to create your own fix update the issue accordingly.
 
-Your project's technical lead can show you where patch files are stored in your project and explain how they are applied.
+Your project's technical lead can show you where any patch files are stored in your project and explain how they are applied.
 
 - [https://www.drupal.org/community/contributor-guide/reference-information/quick-info/life-cycle-of-an-issue](https://www.drupal.org/community/contributor-guide/reference-information/quick-info/life-cycle-of-an-issue)
 - [https://www.drupal.org/docs/develop/using-composer/using-composer-with-drupal](https://www.drupal.org/docs/develop/using-composer/using-composer-with-drupal)

--- a/practice-areas/engineering/drupal/drupal-for-drupal-engineers.md
+++ b/practice-areas/engineering/drupal/drupal-for-drupal-engineers.md
@@ -20,8 +20,8 @@ If you need to create your own fix update the issue accordingly.
 
 Your project's technical lead can show you where any patch files are stored in your project and explain how they are applied.
 
-- [https://www.drupal.org/community/contributor-guide/reference-information/quick-info/life-cycle-of-an-issue](https://www.drupal.org/community/contributor-guide/reference-information/quick-info/life-cycle-of-an-issue)
-- [https://www.drupal.org/docs/develop/using-composer/using-composer-with-drupal](https://www.drupal.org/docs/develop/using-composer/using-composer-with-drupal)
+-   [https://www.drupal.org/community/contributor-guide/reference-information/quick-info/life-cycle-of-an-issue](https://www.drupal.org/community/contributor-guide/reference-information/quick-info/life-cycle-of-an-issue)
+-   [https://www.drupal.org/docs/develop/using-composer/using-composer-with-drupal](https://www.drupal.org/docs/develop/using-composer/using-composer-with-drupal)
 
 ## Version control and the code review process
 


### PR DESCRIPTION
Previously the links were not appearing in the guidebook: https://guidebook.civicactions.com/en/latest/practice-areas/engineering/drupal/drupal-for-drupal-engineers/

Other changes:
- Also updating areas that need some context like some text or a link.
- Had to update `remark-lint-ordered-list-marker-value` because it was flagging lists incorrectly.
- Also need to escape drupal.org links from linkchecker because drupal blocks automation tools.
- Updated contributing section.

In the previous below check that the links are now showing compared the current version of the guidebook.

<!-- readthedocs-preview civicactions-handbook start -->
----
📚 Documentation preview 📚: https://civicactions-handbook--1412.org.readthedocs.build/en/1412/

<!-- readthedocs-preview civicactions-handbook end -->