### PR TITLE
Working on fixing indents on Drupal contribute first module development page

### DIFF
--- a/practice-areas/engineering/drupal/drupal-contrib-first-module-development.md
+++ b/practice-areas/engineering/drupal/drupal-contrib-first-module-development.md
@@ -10,11 +10,9 @@ When a new module is needed we try to follow [Contrib First](../../../common-pra
 2.  Gather requirements and identify MVP vs nice-to-haves
 3.  Search for existing modules that might solve the problem. (It might be easier to stretch an existing module than build a new one)
 4.  If opting to build a new module:
-    <!--lint disable list-item-content-indent code-block-style -->
-        - Choose a meaningful search engine friendly module name. (crowd sourcing name suggestions is recommended)
-        - Create the Drupal project on Drupal.org
-        - Populate the project page with a description of what is coming. List supporters as CivicActions and the client [directions](./README.md#contribution-to-drupalorg-modules-and-themes). If the client does not have a drupal.org page, get help from your PM to encourage them to create one.
-    <!--lint enable list-item-content-indent code-block-style -->
+    -   Choose a meaningful search engine friendly module name. (crowd sourcing name suggestions is recommended)
+    -   Create the Drupal project on Drupal.org
+    -   Populate the project page with a description of what is coming. List supporters as CivicActions and the client [directions](./README.md#contribution-to-drupalorg-modules-and-themes). If the client does not have a drupal.org page, get help from your PM to encourage them to create one.
 5.  Populate the issue queue on the Drupal project with "Feature requests". Keep them as atomic as possible. Mark any that are part of the MVP as "major". Create issues for any improvement ideas that emerge. They don't all have to be acted on, but they help shape the road map for where you want the module to go.
 6.  Close the issues as you go and be sure to credit yourself, CivicActions, and the client.
 7.  Begin with alpha releases. Ideally when all your MVP/major issues are closed, you are ready for the official release.


### PR DESCRIPTION
Lets see if I can do this in a way the linter does not complain about. Looks like the trick is to have 4 spaces for the indent and then 3 after the '-'. E.g.

```
4.  If opting to build a new module:
    -   Choose a meaningful search engine friendly module name. (crowd sourcing name suggestions is recommended)
```

<!-- readthedocs-preview civicactions-handbook start -->
----
📚 Documentation preview 📚: https://civicactions-handbook--1453.org.readthedocs.build/en/1453/

<!-- readthedocs-preview civicactions-handbook end -->