### PR TITLE
Switch from archived mirror repo and pin prettier version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,8 +10,6 @@ repos:
         always_run: true
         pass_filenames: false
         verbose: true
-  - repo: local
-    hooks:
       - id: mkdocs
         name: mkdocs
         language: script
@@ -19,8 +17,6 @@ repos:
         always_run: true
         pass_filenames: false
         verbose: true
-  - repo: local
-    hooks:
       - id: link-check
         name: link-check
         language: docker_image
@@ -28,6 +24,12 @@ repos:
         types: [markdown]
         always_run: true
         pass_filenames: true
+      - id: prettier
+        name: prettier
+        entry: prettier --write --ignore-unknown
+        language: node
+        types: [text]
+        additional_dependencies: ["prettier@3.3.3"]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
@@ -54,10 +56,6 @@ repos:
         types: [markdown]
         args:
           - "--ignore-words=.config/codespell-ignore"
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
-    hooks:
-      - id: prettier
 ci:
   # We skip checks that have their own actions or external dependencies.
   skip: [remark, codespell, mkdocs, link-check]


### PR DESCRIPTION
This seems simpler until the spacing issue is figured out - then we can update the pre-commit version and merge #1481

<!-- readthedocs-preview civicactions-handbook start -->
----
📚 Documentation preview 📚: https://civicactions-handbook--1482.org.readthedocs.build/en/1482/

<!-- readthedocs-preview civicactions-handbook end -->