### PR TITLE
Update linkspector.yml

### DIFF
--- a/.config/linkspector.yml
+++ b/.config/linkspector.yml
@@ -10,3 +10,4 @@ ignorePatterns:
   - pattern: "^https://identity.trinet.com/.*"
   # NOTE: Unreliable sites below
   - pattern: "^https://linux.die.net/.*"
+  - pattern: "^https://www.congress.gov/.*"


### PR DESCRIPTION
The share-it act link gets access denied when GitHub action runs https://github.com/CivicActions/guidebook/actions/runs/14031205818/job/39279059055 so ignore the congress.gov site.

<!-- readthedocs-preview civicactions-handbook start -->
----
📚 Documentation preview 📚: https://civicactions-handbook--1550.org.readthedocs.build/en/1550/

<!-- readthedocs-preview civicactions-handbook end -->