### PR TITLE
Dropping trello link

### DIFF
--- a/practice-areas/engineering/drupal/README.md
+++ b/practice-areas/engineering/drupal/README.md
@@ -22,7 +22,6 @@ CivicActions adopted a standard practice of setting Objectives and Key Results i
 
 We are still in the process of optimizing our OKR practices. That said, Drupal practice area participants have developed practice area OKRs that merge with CivicActions organizational objectives. OKR discussions happen frequently in practice area calls and via:
 
-- [Trello board](https://trello.com/b/MH1OIHzV/drupal-practice-area-okrs)
 - [Culture amp](https://civicactions.cultureamp.com/performance/new_goals/department)
 
 ## Skillsbase: complete a self-assessment of your Drupal skills


### PR DESCRIPTION
## Describe your changes

Removing link from Drupal practice area page.

## Review Steps

- [ ] Confirm link is removed from https://civicactions-handbook--1624.org.readthedocs.build/en/1624/practice-areas/engineering/drupal/?readthedocs-diff=true&readthedocs-diff-chunk=1

## Checklist before requesting review

- [x] Reviewed [documentation](https://guidebook.civicactions.com/en/latest/about-this-guidebook/editing-the-guidebook/#step-4-make-your-pull-request-pr)
- [x] Confirmed all checks for this pull request are passing
