### PR TITLE
Some mkdocs config/script cleanup.

### DIFF
--- a/.config/mkdocs.yml
+++ b/.config/mkdocs.yml
@@ -176,7 +176,16 @@ site_name: CivicActions Guidebook
 repo_url: https://github.com/CivicActions/guidebook/
 site_url: https://guidebook.civicactions.com/en/latest/
 docs_dir: "../.docs"
-exclude_docs: ".*"
+exclude_docs: |
+  ".*"
+  CODE-OF-CONDUCT.md
+  CONTRIBUTING.md
+  SECURITY.md
+validation:
+  omitted_files: warn
+  absolute_links: warn
+  unrecognized_links: warn
+  anchors: warn
 edit_uri: edit/master/
 theme:
   name: material
@@ -227,7 +236,9 @@ markdown_extensions:
           format: !!python/name:pymdownx.superfences.fence_code_format
 plugins:
   - search
-  - git-revision-date-localized
+  - git-revision-date-localized:
+      exclude:
+          - .config/*
 extra_css:
   - assets/css/extra.css
 extra_javascript:


### PR DESCRIPTION
## Describe your changes

A few small changes here:

- Exclude non-docs md files from build - these were creating spurious log messages
- Enable stricter link validation (already passing) - will fail the build with --strict
- Exclude .config from git-revision-date-localized (avoids piles of spurious log messages)
- Switch from using symlink on MacOS to rsync (I assume this is a Mac thing, since it runs fine via Github actions) - this was leading to infinite recursion with git-revision-date-localized. This breaks "serve" for now on MacOS, but I think I am probably the only person using that :)
- Since we have the logs cleaned up and --strict, we can skip the complex log grepping

## Review Steps

- [x] Github Actions runs as usual
- [x] Local builds & pre-commit still work

## Checklist before requesting review

- [x] Reviewed [documentation](https://guidebook.civicactions.com/en/latest/about-this-guidebook/editing-the-guidebook/#step-4-make-your-pull-request-pr)
- [x] Confirmed all checks for this pull request are passing


<!-- readthedocs-preview civicactions-handbook start -->
----
📚 Documentation preview 📚: https://civicactions-handbook--1669.org.readthedocs.build/en/1669/

<!-- readthedocs-preview civicactions-handbook end -->