### PR TITLE
Add ecosia.org pattern to linkspector configuration to ignore those links

### DIFF
--- a/.config/linkspector.yml
+++ b/.config/linkspector.yml
@@ -13,3 +13,4 @@ ignorePatterns:
   - pattern: "^https://www.congress.gov/.*"
   - pattern: "^https://www.gnu.org/.*"
   - pattern: "^https://medium.com/.*"
+  - pattern: "^https://.*ecosia.org/.*"


### PR DESCRIPTION
## Describe your changes

Currently those links return 403s, e.g. https://github.com/CivicActions/guidebook/actions/runs/22569116281/job/65372121530

## Review Steps

- [ ] Review the configuration changes and that link checkers passes

## Checklist before requesting review

- [x] Reviewed [documentation](https://guidebook.civicactions.com/en/latest/about-this-guidebook/editing-the-guidebook/#step-4-make-your-pull-request-pr)
- [x] Confirmed all checks for this pull request are passing


<!-- readthedocs-preview civicactions-handbook start -->
----
📚 Documentation preview 📚: https://civicactions-handbook--1713.org.readthedocs.build/en/1713/

<!-- readthedocs-preview civicactions-handbook end -->